### PR TITLE
fix: incorrect line numbers in audit report findings

### DIFF
--- a/src/ossature/audit/audit.py
+++ b/src/ossature/audit/audit.py
@@ -11,14 +11,20 @@ from ossature.config.loader import OssatureConfig
 from ossature.models.amd import AMDSpec
 from ossature.models.audit import CrossSpecAuditReport, SpecAuditReport
 from ossature.models.smd import SMDSpec
-from ossature.renderer.amd import render_amd
-from ossature.renderer.smd import render_smd
+
+
+def _read_numbered(path: Path) -> str:
+    """Read a file and prefix each line with its line number."""
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    numbered = [f"L{i}: {line}" for i, line in enumerate(lines, 1)]
+    return "\n".join(numbered)
 
 
 def audit_spec(
     config: OssatureConfig,
-    smd: SMDSpec,
-    amds: list[AMDSpec] | None = None,
+    smd_path: Path,
+    amd_paths: list[Path] | None = None,
 ) -> SpecAuditReport:
     agent = Agent(
         config.llm.model_for("audit"),
@@ -29,12 +35,12 @@ def audit_spec(
     sections: list[str] = []
 
     sections.append("# Specification (SMD)\n")
-    sections.append(render_smd(smd))
+    sections.append(_read_numbered(smd_path))
 
-    if amds:
+    if amd_paths:
         sections.append("\n# Architecture Documents (AMD)\n")
-        for amd in amds:
-            sections.append(render_amd(amd))
+        for amd_path in amd_paths:
+            sections.append(_read_numbered(amd_path))
 
     result = agent.run_sync("\n---\n".join(sections))
 

--- a/src/ossature/audit/prompts.py
+++ b/src/ossature/audit/prompts.py
@@ -42,11 +42,13 @@ SPEC_AUDIT_SYSTEM_PROMPT: Final[str] = (
     "Don't invent findings. An empty array is a valid output for a well-written spec.\n"
     "</instructions>\n\n"
     "<output_format>\n"
+    "The input documents have line numbers prefixed as `L<number>: `. "
+    "Use these exact line numbers in your location references.\n\n"
     "For each finding, output JSON:\n"
     '{{"severity": "error"|"warning"|"info",'
-    ' "location": "location in the markdown doc without header marks, just text, arrow separated, '
-    'include headers text and number (if list)" and line number, '
-    '"issue": "description", "suggestion": "how to fix"}}\n\n'
+    ' "location": "section path without header marks, arrow separated'
+    ' (e.g. Requirements > Token Format), L<number>",'
+    ' "issue": "description", "suggestion": "how to fix"}}\n\n'
     "Output a JSON array of findings. Empty array if none found.\n"
     "</output_format>\n\n"
     "<examples>\n"
@@ -55,7 +57,7 @@ SPEC_AUDIT_SYSTEM_PROMPT: Final[str] = (
     'requirement 7 says "users stay logged in indefinitely."\n\n'
     "Output:\n"
     '[{{"severity": "error", '
-    '"location": "Requirements > 7. Session Persistence", '
+    '"location": "Requirements > 7. Session Persistence, L42", '
     '"issue": "Requirement 7 says users stay logged in indefinitely, but requirement 3 '
     "defines a 24-hour token expiry. These are incompatible — either sessions expire "
     "or they don\\'t.\", "

--- a/src/ossature/cli/commands/audit.py
+++ b/src/ossature/cli/commands/audit.py
@@ -494,6 +494,12 @@ def run_audit(
         spec_file_map = _build_spec_file_map(
             smd_files, amd_files, parsed_smds, parsed_amds, config.spec_path
         )
+        amd_file_map = _build_amd_file_map(amd_files, parsed_amds, config.spec_path)
+
+        # Build spec_id -> absolute SMD path mapping
+        smd_path_map: dict[str, Path] = {}
+        for smd_file, parsed in zip(smd_files, parsed_smds):
+            smd_path_map[parsed.spec_id] = smd_file
 
         for smd in parsed_smds:
             spec_amds = amd_by_spec.get(smd.spec_id)
@@ -507,7 +513,11 @@ def run_audit(
                     else:
                         status.update(f"Auditing {smd.spec_id} - {smd.title}")
 
-                    report = audit_spec(config, smd, spec_amds)
+                    smd_path = smd_path_map[smd.spec_id]
+                    spec_amd_paths = [
+                        config.spec_path / rel for rel in amd_file_map.get(smd.spec_id, [])
+                    ]
+                    report = audit_spec(config, smd_path, spec_amd_paths or None)
                     save_spec_audit_data(report, smd.spec_id, audit_data_dir)
                     spec_reports[smd.spec_id] = report
                     audited_spec_ids.add(smd.spec_id)

--- a/tests/unit/test_audit_read_numbered.py
+++ b/tests/unit/test_audit_read_numbered.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from ossature.audit.audit import _read_numbered
+
+
+class TestReadNumbered:
+    def test_prefixes_each_line(self, temp_dir: Path):
+        f = temp_dir / "test.smd"
+        f.write_text("# Title\n\n@id: TEST\n", encoding="utf-8")
+
+        result = _read_numbered(f)
+        lines = result.splitlines()
+
+        assert lines[0] == "L1: # Title"
+        assert lines[1] == "L2: "
+        assert lines[2] == "L3: @id: TEST"
+
+    def test_sequential_numbering(self, temp_dir: Path):
+        f = temp_dir / "test.smd"
+        f.write_text("line one\nline two\nline three\n", encoding="utf-8")
+
+        result = _read_numbered(f)
+        lines = result.splitlines()
+
+        for i, line in enumerate(lines, 1):
+            assert line.startswith(f"L{i}: "), f"Line {i} has wrong prefix: {line!r}"
+
+    def test_preserves_content(self, temp_dir: Path):
+        original = "# My Spec\n\n## Overview\n\nSome text.\n"
+        f = temp_dir / "test.smd"
+        f.write_text(original, encoding="utf-8")
+
+        result = _read_numbered(f)
+        original_lines = original.splitlines()
+        numbered_lines = result.splitlines()
+
+        assert len(original_lines) == len(numbered_lines)
+        for i, (orig, numbered) in enumerate(zip(original_lines, numbered_lines), 1):
+            assert numbered == f"L{i}: {orig}"
+
+    def test_single_line_file(self, temp_dir: Path):
+        f = temp_dir / "test.smd"
+        f.write_text("only line", encoding="utf-8")
+
+        result = _read_numbered(f)
+
+        assert result == "L1: only line"
+
+    def test_empty_file(self, temp_dir: Path):
+        f = temp_dir / "test.smd"
+        f.write_text("", encoding="utf-8")
+
+        result = _read_numbered(f)
+
+        assert result == ""


### PR DESCRIPTION
**What does this change?**

Fixes incorrect line numbers in audit report findings. Previously, the auditor sent rendered (re-serialized) spec content to the LLM, which didn't preserve original line numbers. Now it reads the raw spec files and prefixes each line with its actual line number (L1:, L2:, …), and the audit prompt instructs the LLM to use those exact line numbers in its location references.

**How was it tested?**

Unit tests added for the `_read_numbered` helper covering line-number prefixing, sequential numbering, content preservation, single-line files, and empty files (`tests/unit/test_audit_read_numbered.py`), and manually verified on example projects that audit findings now report correct line numbers matching the source spec files.