### PR TITLE
feat: non-interactive audit by default, typed edit_file tool

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -42,20 +42,36 @@ What it does, in order:
 
 1. Validates everything (same checks as `validate`)
 2. Builds the spec dependency graph, writes `.ossature/graph.toml`
-3. Computes checksums of all source files, compares to saved manifest. If nothing changed, asks whether to re-audit
+3. Computes checksums of all source files, compares to saved manifest. If nothing changed, skips re-audit
 4. Audits each changed spec with the LLM, looking for ambiguity, contradictions, gaps, and feasibility issues
-5. Runs a cross-spec audit if there are multiple specs, checking for interface mismatches
-6. Writes the audit report to `.ossature/audit-report.md`
-7. Generates a project brief and per-spec briefs
-8. Extracts or infers interface signatures for each spec
-9. Generates the build plan, writes `.ossature/plan.toml`
+5. Auto-fixes errors (up to 3 cycles per spec), re-auditing after each fix
+6. Runs a cross-spec audit if there are multiple specs, checking for interface mismatches
+7. Writes the audit report to `.ossature/audit-report.md`
+8. Generates a project brief and per-spec briefs
+9. Extracts or infers interface signatures for each spec
+10. Generates the build plan, writes `.ossature/plan.toml`
+11. Exits with code 1 if any audit errors remain unresolved
+
+By default, the audit runs **non-interactively**: it auto-fixes errors without prompting, prints a consolidated findings table at the end, and exits with code 1 if errors remain.
 
 When only some specs changed, audit runs **incrementally**: only the changed specs are re-planned, while tasks for unchanged specs are preserved with their existing hashes. Stale output files from tasks that no longer exist in the new plan are automatically removed. The project brief is also skipped during incremental audits to avoid invalidating input hashes for all preserved tasks.
 
-Use `--replan` to force a full plan regeneration, discarding manual edits and any incremental state:
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--replan` | Force a full plan regeneration, discarding manual edits |
+| `--interactive`, `-i` | Prompt before each auto-fix; offers to fix warnings too |
+| `--no-fix` | Audit only, never attempt auto-fix |
+| `--errors-ok` | Exit 0 even when audit errors remain |
+
+`--interactive` and `--no-fix` are mutually exclusive.
 
 ```bash
-ossature audit --replan
+ossature audit --replan         # force full plan regeneration
+ossature audit -i               # interactive mode with prompts
+ossature audit --no-fix         # just show findings, don't fix
+ossature audit --errors-ok      # don't fail on remaining errors
 ```
 
 ## ossature build

--- a/docs/configuration/ossature-toml.md
+++ b/docs/configuration/ossature-toml.md
@@ -42,11 +42,20 @@ language = "python"      # target language
 
 The `language` field tells the LLM what language to generate. It's not limited to a fixed list, but you'll get best results with common languages like python, typescript, rust, go, lua, etc.
 
+## Audit Section
+
+```toml
+[audit]
+max_fix_cycles = 3       # audit → fix → re-audit cycles per spec
+```
+
+Controls how many times the audit will attempt to fix errors in a spec and re-audit it. Each cycle sends the findings to the fixer LLM, applies edits, then re-audits the changed file. Defaults to 3.
+
 ## Build Section
 
 ```toml
 [build]
-max_fix_attempts = 3     # how many times to retry fixing a failed task
+max_fix_attempts = 3     # verify-fail → fix → re-verify cycles per task
 setup = "cargo init"     # optional: run before the first task
 verify = "cargo check"   # optional: override default verification command
 test = "cargo test"      # optional: override default test command
@@ -65,12 +74,15 @@ model = "anthropic:claude-sonnet-4-6"
 
 The model format is `provider:model-name`. Supported providers are `anthropic` and `ollama`.
 
-The `retries` field controls how many times an agent retries when the model returns an invalid structured response or a tool call fails validation. Defaults to 3. Increase for less capable or local models, decrease if you want faster failures.
+The `retries` field controls how many times an agent retries when the model returns an invalid structured response (e.g., malformed JSON output). Defaults to 3.
+
+The `tool_retries` field controls how many times a tool call can be retried when the LLM makes a mistake (e.g., `edit_file` with text that doesn't match the file). Defaults to 5. Increase for less capable or local models.
 
 ```toml
 [llm]
 model = "anthropic:claude-sonnet-4-6"
 retries = 5
+tool_retries = 8
 ```
 
 Set your API key as an environment variable:

--- a/docs/getting-started/workflow.md
+++ b/docs/getting-started/workflow.md
@@ -151,7 +151,7 @@ tags: "example,test", created_at: "2026-01-01 00:00:00" }]
 ```
 ````
 
-The audit also offers auto-fix, where the LLM edits your spec files directly to resolve findings. You're prompted before any edits are made. After audit completes, all findings are saved to `.ossature/audit-report.md`.
+By default, the audit auto-fixes errors without prompting — it edits your spec files directly, re-audits, and repeats up to 3 cycles per spec. Warnings and info are reported but not auto-fixed. Use `--interactive` if you want to approve each fix, or `--no-fix` to skip fixing entirely. After audit completes, all findings are saved to `.ossature/audit-report.md`.
 
 ### Incremental audits
 

--- a/src/ossature/audit/fixer.py
+++ b/src/ossature/audit/fixer.py
@@ -1,9 +1,9 @@
-import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic_ai import Agent, ModelRetry, RunContext
+from pydantic_ai.exceptions import UnexpectedModelBehavior
 from rich.console import Console
 from rich.status import Status
 
@@ -11,6 +11,14 @@ from ossature.audit.prompts import SPEC_FIXER_SYSTEM_PROMPT
 from ossature.config.loader import OssatureConfig
 from ossature.models.audit import AuditFinding, CrossSpecFinding, Severity
 from ossature.shared import apply_edits
+
+
+def _format_fix_error(e: Exception) -> str:
+    """Extract a useful error message, including the root cause from retries."""
+    if isinstance(e, UnexpectedModelBehavior) and e.__cause__:
+        return f"{e.message}: {e.__cause__}"
+    return str(e)
+
 
 # Process errors first, then warnings, then info
 _SEVERITY_ORDER = {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2}
@@ -78,7 +86,7 @@ def _register_fixer_tools(agent: Agent[FixContext, str]) -> None:
             return f"Error reading {path}: {e}"
 
     @agent.tool
-    def edit_file(ctx: RunContext[FixContext], path: str, edits: str) -> str:
+    def edit_file(ctx: RunContext[FixContext], path: str, edits: list[dict[str, str]]) -> str:
         full_path = _resolve_spec_sandboxed(ctx.deps.spec_dir, path)
         try:
             if not full_path.exists():
@@ -96,10 +104,9 @@ def _register_fixer_tools(agent: Agent[FixContext, str]) -> None:
         if path not in ctx.deps.edited_files:
             ctx.deps.edited_files.append(path)
 
-        n_edits = len(json.loads(edits))
         ctx.deps.status.update(f"fixing -- edited {path}")
-        ctx.deps.console.log(f"    edited [bold]{path}[/bold] ({n_edits} edit(s))")
-        return f"Edited: {path} ({n_edits} edit(s) applied)"
+        ctx.deps.console.log(f"    edited [bold]{path}[/bold] ({len(edits)} edit(s))")
+        return f"Edited: {path} ({len(edits)} edit(s) applied)"
 
 
 def _create_fixer_agent(config: OssatureConfig) -> Agent[FixContext, str]:
@@ -107,7 +114,7 @@ def _create_fixer_agent(config: OssatureConfig) -> Agent[FixContext, str]:
         config.llm.model_for("fixer"),
         system_prompt=SPEC_FIXER_SYSTEM_PROMPT,
         deps_type=FixContext,
-        retries=config.llm.retries,
+        retries=config.llm.tool_retries,
         model_settings={"max_tokens": 8192},
     )
     _register_fixer_tools(agent)
@@ -195,7 +202,7 @@ def fix_spec_findings(
                     all_edited.append(f)
 
         except Exception as e:
-            console.log(f"    [red]Fix failed: {e} — skipping[/red]")
+            console.log(f"    [red]Fix failed: {_format_fix_error(e)} — skipping[/red]")
             full_path.write_text(backup)
 
     return all_edited
@@ -261,7 +268,7 @@ def fix_cross_spec_findings(
                     all_edited.append(f)
 
         except Exception as e:
-            console.log(f"    [red]Fix failed: {e} — skipping[/red]")
+            console.log(f"    [red]Fix failed: {_format_fix_error(e)} — skipping[/red]")
             for full_path, content in backups.items():
                 full_path.write_text(content)
 

--- a/src/ossature/audit/prompts.py
+++ b/src/ossature/audit/prompts.py
@@ -227,6 +227,13 @@ SPEC_FIXER_SYSTEM_PROMPT: Final[str] = (
     "You are a specification editor. You make minimal, surgical edits to software "
     "specification files (.smd or .amd) to address audit findings.\n"
     "</role>\n\n"
+    "<tools>\n"
+    "- `read_file(path)` — read the full contents of a spec file\n"
+    "- `grep_file(path, pattern)` — search for a pattern in a spec file\n"
+    "- `edit_file(path, edits)` — apply targeted edits to a spec file. "
+    '`edits` is a list of {{"old": "exact text to find", "new": "replacement text"}} objects. '
+    "Each `old` must match exactly once in the file. Edits are applied in order.\n"
+    "</tools>\n\n"
     "<instructions>\n"
     "You will receive an audit finding with a location, issue description, and suggested fix. "
     "Your job is to edit the specification file to address the finding.\n\n"

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -1,4 +1,3 @@
-import json
 import re
 import shlex
 import shutil
@@ -160,7 +159,7 @@ def _register_tools(agent: Agent[BuildContext, str]) -> None:
         return f"Written: {path} ({len(content)} bytes, {line_count} lines)"
 
     @agent.tool
-    def edit_file(ctx: RunContext[BuildContext], path: str, edits: str) -> str:
+    def edit_file(ctx: RunContext[BuildContext], path: str, edits: list[dict[str, str]]) -> str:
         full_path = _resolve_sandboxed(ctx.deps.output_dir, path, ctx.deps.console)
         try:
             if not full_path.exists():
@@ -181,10 +180,9 @@ def _register_tools(agent: Agent[BuildContext, str]) -> None:
         if path not in ctx.deps.written_files:
             ctx.deps.written_files.append(path)
 
-        n_edits = len(json.loads(edits))
         ctx.deps.set_phase(f"-- edited {path}")
-        ctx.deps.log_tool(f"      edited [bold]{path}[/bold] ({n_edits} edit(s))")
-        return f"Edited: {path} ({n_edits} edit(s) applied)"
+        ctx.deps.log_tool(f"      edited [bold]{path}[/bold] ({len(edits)} edit(s))")
+        return f"Edited: {path} ({len(edits)} edit(s) applied)"
 
     @agent.tool
     def read_file(ctx: RunContext[BuildContext], path: str) -> str:
@@ -343,7 +341,7 @@ def _create_impl_agent(config: OssatureConfig) -> Agent[BuildContext, str]:
         config.llm.model_for("build"),
         system_prompt=IMPLEMENTER_SYSTEM_PROMPT.format(language=config.output.language),
         deps_type=BuildContext,
-        retries=config.llm.retries,
+        retries=config.llm.tool_retries,
         model_settings={"max_tokens": 16384},
     )
     _register_tools(agent)
@@ -355,7 +353,7 @@ def _create_fix_agent(config: OssatureConfig) -> Agent[BuildContext, str]:
         config.llm.model_for("build"),
         system_prompt=FIXER_SYSTEM_PROMPT.format(language=config.output.language),
         deps_type=BuildContext,
-        retries=config.llm.retries,
+        retries=config.llm.tool_retries,
         model_settings={"max_tokens": 16384},
     )
     _register_tools(agent)

--- a/src/ossature/build/prompts.py
+++ b/src/ossature/build/prompts.py
@@ -21,8 +21,7 @@ IMPLEMENTER_SYSTEM_PROMPT: Final[str] = (
     "<tools>\n"
     "- `write_file(path, content)` — create a new file or fully rewrite one\n"
     "- `edit_file(path, edits)` — apply targeted edits to an existing file. "
-    "`edits` is a JSON array: "
-    '[{{"old": "exact text to find", "new": "replacement text"}}]. '
+    '`edits` is a list of {{"old": "exact text to find", "new": "replacement text"}} objects. '
     "Each `old` must match exactly once in the file. Edits are applied in order.\n"
     "- `read_file(path)` — read a full file\n"
     "- `read_lines(path, start_line, end_line)` — read specific line range\n"
@@ -54,8 +53,7 @@ FIXER_SYSTEM_PROMPT: Final[str] = (
     "</role>\n\n"
     "<tools>\n"
     "- `edit_file(path, edits)` — apply targeted edits to a file. "
-    "`edits` is a JSON array: "
-    '[{{"old": "exact text to find", "new": "replacement text"}}]. '
+    '`edits` is a list of {{"old": "exact text to find", "new": "replacement text"}} objects. '
     "Each `old` must match exactly once. Edits are applied in order.\n"
     "- `write_file(path, content)` — create or fully rewrite a file\n"
     "- `read_file(path)` — read a full file\n"

--- a/src/ossature/cli/commands/audit.py
+++ b/src/ossature/cli/commands/audit.py
@@ -49,6 +49,8 @@ from ossature.models.smd import SMDSpec
 from ossature.parsers.amd import AMDParseError, parse_amd_file
 from ossature.parsers.smd import SMDParseError, parse_smd_file
 
+FixMode = str  # "auto" | "interactive" | "none"
+
 
 class ValidationError(Exception): ...
 
@@ -118,58 +120,23 @@ def print_audit_findings_table(
     console.print()
 
 
-def present_findings_and_confirm(
-    console: Console,
-    status: Status,
-    report: SpecAuditReport | CrossSpecAuditReport,
-) -> None:
-
-    if not report.findings:
-        return
-
-    counts = {s: 0 for s in Severity}
-    for finding in report.findings:
-        counts[finding.severity] += 1
-
-    status.stop()
-
-    if questionary.confirm("Print full report?").ask():
-        print_audit_findings_table(console, report=report)
-
-    some_errors = counts[Severity.ERROR] > 0
-
-    if (
-        some_errors
-        and not questionary.confirm(
-            f"Audit found {counts[Severity.ERROR]} error(s). Continue?", default=False
-        ).ask()
-    ):
-        raise SystemExit(1)
-
-    status.start()
-
-
-MAX_FIX_CYCLES = 3
-
-
-def _has_fixable_findings(
+def _has_fixable_errors(
     report: SpecAuditReport | CrossSpecAuditReport,
 ) -> bool:
-    return any(f.suggestion for f in report.findings)
+    return any(f.severity == Severity.ERROR and f.suggestion for f in report.findings)
+
+
+def _fixable_error_count(
+    report: SpecAuditReport | CrossSpecAuditReport,
+) -> int:
+    return sum(1 for f in report.findings if f.severity == Severity.ERROR and f.suggestion)
 
 
 def _fixable_finding_count(
     report: SpecAuditReport | CrossSpecAuditReport,
 ) -> int:
-    # Skip info-level findings when there are errors or warnings.
-    has_errors_or_warnings = any(
-        f.severity in (Severity.ERROR, Severity.WARNING) for f in report.findings
-    )
-    return sum(
-        1
-        for f in report.findings
-        if f.suggestion and not (f.severity == Severity.INFO and has_errors_or_warnings)
-    )
+    """Count fixable findings across all severities (for --interactive mode)."""
+    return sum(1 for f in report.findings if f.suggestion)
 
 
 def _build_spec_file_map(
@@ -388,7 +355,11 @@ def run_audit(
     verbose: bool,
     console: Console,
     replan: bool = False,
+    interactive: bool = False,
+    no_fix: bool = False,
+    errors_ok: bool = False,
 ) -> None:
+    fix_mode: FixMode = "interactive" if interactive else ("none" if no_fix else "auto")
     try:
         config = load_config(config_path)
     except ConfigError as e:
@@ -424,14 +395,18 @@ def run_audit(
         changed_files = check_and_update_manifest(console, config, smd_files, amd_files)
 
         if changed_files is None:
-            status.stop()
-            if questionary.confirm(
-                "Re-audit is not required. Re-audit anyway?", default=False
-            ).ask():
-                specs_to_audit = {smd.spec_id for smd in parsed_smds}
+            if interactive:
+                status.stop()
+                if questionary.confirm(
+                    "Re-audit is not required. Re-audit anyway?", default=False
+                ).ask():
+                    specs_to_audit = {smd.spec_id for smd in parsed_smds}
+                else:
+                    specs_to_audit = set()
+                status.start()
             else:
+                console.log("[green]No changes detected — skipping re-audit")
                 specs_to_audit = set()
-            status.start()
         else:
             specs_to_audit = get_changed_spec_ids(
                 changed_files, smd_files, amd_files, parsed_smds, parsed_amds, config
@@ -507,7 +482,8 @@ def run_audit(
             if smd.spec_id in specs_to_audit:
                 spec_file = spec_file_map[smd.spec_id]
 
-                for fix_cycle in range(MAX_FIX_CYCLES + 1):
+                max_cycles = config.audit.max_fix_cycles
+                for fix_cycle in range(max_cycles + 1):
                     if fix_cycle > 0:
                         status.update(f"Re-auditing {smd.spec_id} (cycle {fix_cycle + 1})")
                     else:
@@ -528,32 +504,33 @@ def run_audit(
                     summary = ", ".join(f"{v} {k.value}(s)" for k, v in counts.items() if v > 0)
                     console.log(f"  {smd.spec_id}: {summary or 'no findings'}")
 
-                    if not report.findings or not _has_fixable_findings(report):
-                        break
-                    if fix_cycle >= MAX_FIX_CYCLES:
+                    # Decide whether to attempt fixes
+                    if fix_mode == "none" or fix_cycle >= max_cycles:
                         break
 
-                    print_audit_summary(
-                        console,
-                        report=report,
-                        title=f"{smd.spec_id} Audit",
-                    )
-                    present_findings_and_confirm(console, status, report)
+                    if fix_mode == "auto":
+                        if not _has_fixable_errors(report):
+                            break
+                    else:  # interactive
+                        if not report.findings or not _fixable_finding_count(report):
+                            break
 
-                    fixable = _fixable_finding_count(report)
-                    status.stop()
-                    if not questionary.confirm(
-                        f"Auto-fix {fixable} finding(s) in {smd.spec_id}?"
-                        + (
-                            " (info-level findings deferred until errors/warnings are resolved)"
-                            if fixable < len(report.findings)
-                            else ""
-                        ),
-                        default=False,
-                    ).ask():
+                        print_audit_summary(
+                            console,
+                            report=report,
+                            title=f"{smd.spec_id} Audit",
+                        )
+                        print_audit_findings_table(console, report=report)
+
+                        fixable = _fixable_finding_count(report)
+                        status.stop()
+                        if not questionary.confirm(
+                            f"Auto-fix {fixable} finding(s) in {smd.spec_id}?",
+                            default=True,
+                        ).ask():
+                            status.start()
+                            break
                         status.start()
-                        break
-                    status.start()
 
                     status.update(f"Fixing {smd.spec_id} findings")
                     edited = fix_spec_findings(
@@ -588,7 +565,7 @@ def run_audit(
                     spec_reports[smd.spec_id] = cached
                     console.log(f"  {smd.spec_id} - {smd.title}: [dim](cached)[/dim]")
 
-        # Present findings for freshly audited specs
+        # Present consolidated findings for freshly audited specs
         if audited_spec_ids:
             fresh_findings = SpecAuditReport(
                 findings=[
@@ -605,12 +582,16 @@ def run_audit(
                 title=f"{config.name} v{config.version} - Spec Audit",
             )
 
+            if fresh_findings.findings:
+                print_audit_findings_table(console, report=fresh_findings)
+
         # - CROSS-SPEC AUDIT
         cross_spec_report: CrossSpecAuditReport | None = None
 
         if len(parsed_smds) > 1:
             if audited_spec_ids:
-                for fix_cycle in range(MAX_FIX_CYCLES + 1):
+                max_cycles = config.audit.max_fix_cycles
+                for fix_cycle in range(max_cycles + 1):
                     if fix_cycle > 0:
                         status.update(f"Re-running cross-spec audit (cycle {fix_cycle + 1})")
                     else:
@@ -619,35 +600,41 @@ def run_audit(
                     cross_spec_report = audit_cross_specs(config, parsed_smds, parsed_amds)
                     save_cross_spec_audit_data(cross_spec_report, audit_data_dir)
 
-                    print_audit_summary(
-                        console,
-                        report=cross_spec_report,
-                        title=f"{config.name} v{config.version} - Cross-Spec Audit",
-                    )
+                    counts = {s: 0 for s in Severity}
+                    for cs_finding in cross_spec_report.findings:
+                        counts[cs_finding.severity] += 1
+                    summary = ", ".join(f"{v} {k.value}(s)" for k, v in counts.items() if v > 0)
+                    console.log(f"  Cross-spec: {summary or 'no findings'}")
 
-                    if not cross_spec_report.findings or not _has_fixable_findings(
-                        cross_spec_report
-                    ):
-                        break
-                    if fix_cycle >= MAX_FIX_CYCLES:
+                    # Decide whether to attempt fixes
+                    if fix_mode == "none" or fix_cycle >= max_cycles:
                         break
 
-                    present_findings_and_confirm(console, status, cross_spec_report)
+                    if fix_mode == "auto":
+                        if not _has_fixable_errors(cross_spec_report):
+                            break
+                    else:  # interactive
+                        if not cross_spec_report.findings or not _fixable_finding_count(
+                            cross_spec_report
+                        ):
+                            break
 
-                    fixable = _fixable_finding_count(cross_spec_report)
-                    status.stop()
-                    if not questionary.confirm(
-                        f"Auto-fix {fixable} cross-spec finding(s)?"
-                        + (
-                            " (info-level findings deferred until errors/warnings are resolved)"
-                            if fixable < len(cross_spec_report.findings)
-                            else ""
-                        ),
-                        default=False,
-                    ).ask():
+                        print_audit_summary(
+                            console,
+                            report=cross_spec_report,
+                            title=f"{config.name} v{config.version} - Cross-Spec Audit",
+                        )
+                        print_audit_findings_table(console, report=cross_spec_report)
+
+                        fixable = _fixable_finding_count(cross_spec_report)
+                        status.stop()
+                        if not questionary.confirm(
+                            f"Auto-fix {fixable} cross-spec finding(s)?",
+                            default=True,
+                        ).ask():
+                            status.start()
+                            break
                         status.start()
-                        break
-                    status.start()
 
                     status.update("Fixing cross-spec findings")
                     edited = fix_cross_spec_findings(
@@ -672,6 +659,15 @@ def run_audit(
                         rel = spec_file_map.get(smd_obj.spec_id, "")
                         if rel in edited:
                             parsed_smds[smd_idx] = parse_smd_file(config.spec_path / rel)
+
+                # Print consolidated cross-spec findings
+                if cross_spec_report and cross_spec_report.findings:
+                    print_audit_summary(
+                        console,
+                        report=cross_spec_report,
+                        title=f"{config.name} v{config.version} - Cross-Spec Audit",
+                    )
+                    print_audit_findings_table(console, report=cross_spec_report)
             else:
                 cross_spec_report = load_cross_spec_audit_data(audit_data_dir)
 
@@ -729,14 +725,17 @@ def run_audit(
         needs_plan = bool(audited_spec_ids) or not plan_filepath.exists() or replan
 
         if replan and plan_filepath.exists():
-            status.stop()
-            if not questionary.confirm(
-                "This will overwrite the existing plan (discarding manual edits). Continue?",
-                default=False,
-            ).ask():
-                console.print("[yellow]Plan regeneration skipped.")
-                return
-            status.start()
+            if interactive:
+                status.stop()
+                if not questionary.confirm(
+                    "This will overwrite the existing plan (discarding manual edits). Continue?",
+                    default=False,
+                ).ask():
+                    console.print("[yellow]Plan regeneration skipped.")
+                    return
+                status.start()
+            else:
+                console.log("[yellow]--replan: overwriting existing plan")
 
         if not needs_plan:
             console.log("[yellow]Plan regeneration not required")
@@ -807,3 +806,16 @@ def run_audit(
             console.print(f"  Review the plan:  [cyan]{plan_filepath}[/cyan]")
             console.print("  Start building:   [cyan]ossature build[/cyan]")
             console.print()
+
+        # Exit 1 if audit errors remain (unless --errors-ok)
+        if not errors_ok:
+            error_count = sum(
+                1 for r in spec_reports.values() for f in r.findings if f.severity == Severity.ERROR
+            )
+            if cross_spec_report:
+                error_count += sum(
+                    1 for f in cross_spec_report.findings if f.severity == Severity.ERROR
+                )
+            if error_count:
+                console.print(f"[red]Audit completed with {error_count} unresolved error(s).[/red]")
+                raise SystemExit(1)

--- a/src/ossature/cli/main.py
+++ b/src/ossature/cli/main.py
@@ -105,19 +105,47 @@ def validate(
     is_flag=True,
     help="Regenerate the build plan (discards manual edits to plan.toml)",
 )
+@click.option(
+    "--interactive",
+    "-i",
+    is_flag=True,
+    help="Prompt before each auto-fix (default runs non-interactively)",
+)
+@click.option(
+    "--no-fix",
+    is_flag=True,
+    help="Audit only, never attempt auto-fix",
+)
+@click.option(
+    "--errors-ok",
+    is_flag=True,
+    help="Exit 0 even when audit errors remain",
+)
 @click.pass_context
 def audit(
     ctx: click.Context,
     replan: bool,
+    interactive: bool,
+    no_fix: bool,
+    errors_ok: bool,
 ) -> None:
     """Semantically audit the specifications and generate build plan metadata."""
     from ossature.cli.commands.audit import run_audit
+
+    if interactive and no_fix:
+        ctx.obj["console"].print(
+            "[red]Error:[/] --interactive and --no-fix are mutually exclusive."
+        )
+        raise SystemExit(1)
 
     run_audit(
         config_path=ctx.obj["config_path"],
         verbose=ctx.obj["verbose"],
         console=ctx.obj["console"],
         replan=replan,
+        interactive=interactive,
+        no_fix=no_fix,
+        errors_ok=errors_ok,
     )
 
 

--- a/src/ossature/config/loader.py
+++ b/src/ossature/config/loader.py
@@ -26,6 +26,11 @@ class TestConfig:
 
 
 @dataclass
+class AuditConfig:
+    max_fix_cycles: int = 3
+
+
+@dataclass
 class BuildConfig:
     max_fix_attempts: int = 3
     setup: str | None = None
@@ -50,6 +55,7 @@ class LLMConfig:
     fixer: str | None = None
     ollama_base_url: str = DEFAULT_OLLAMA_BASE_URL
     retries: int = 3
+    tool_retries: int = 5
 
     @property
     def uses_ollama(self) -> bool:
@@ -80,6 +86,7 @@ class OssatureConfig:
 
     output: OutputConfig = field(default_factory=OutputConfig)
     test: TestConfig = field(default_factory=TestConfig)
+    audit: AuditConfig = field(default_factory=AuditConfig)
     build: BuildConfig = field(default_factory=BuildConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
 
@@ -150,6 +157,12 @@ def _parse_test_config(data: dict[str, Any]) -> TestConfig:
     )
 
 
+def _parse_audit_config(data: dict[str, Any]) -> AuditConfig:
+    return AuditConfig(
+        max_fix_cycles=int(data.get("max_fix_cycles", 3)),
+    )
+
+
 def _parse_build_config(data: dict[str, Any]) -> BuildConfig:
     return BuildConfig(
         max_fix_attempts=int(data.get("max_fix_attempts", 3)),
@@ -170,6 +183,7 @@ def _parse_llm_config(data: dict[str, Any]) -> LLMConfig:
         fixer=data.get("fixer"),
         ollama_base_url=data.get("ollama_base_url", DEFAULT_OLLAMA_BASE_URL),
         retries=int(data.get("retries", 3)),
+        tool_retries=int(data.get("tool_retries", 5)),
     )
 
 
@@ -211,6 +225,7 @@ def load_config(path: Path | None = None) -> OssatureConfig:
         context_dir=project.get("context_dir", "context"),
         output=_parse_output_config(data.get("output", {})),
         test=_parse_test_config(data.get("test", {})),
+        audit=_parse_audit_config(data.get("audit", {})),
         build=_parse_build_config(data.get("build", {})),
         llm=_parse_llm_config(llm_data),
         root=path.parent,

--- a/src/ossature/shared/__init__.py
+++ b/src/ossature/shared/__init__.py
@@ -3,26 +3,29 @@ import json
 from pydantic_ai import ModelRetry
 
 
-def apply_edits(content: str, edits_json: str) -> str:
-    try:
-        edits = json.loads(edits_json)
-    except json.JSONDecodeError as e:
-        raise ModelRetry(
-            f"Could not parse edits JSON: {e}. "
-            f"The `edits` parameter must be a valid JSON array of objects, e.g. "
-            f'[{{"old": "old text", "new": "new text"}}]'
-        )
+def apply_edits(content: str, edits: list[dict[str, str]] | str) -> str:
+    if isinstance(edits, str):
+        try:
+            parsed = json.loads(edits)
+        except json.JSONDecodeError as e:
+            raise ModelRetry(
+                f"Could not parse edits JSON: {e}. "
+                f"The `edits` parameter must be a valid JSON array of objects, e.g. "
+                f'[{{"old": "old text", "new": "new text"}}]'
+            )
+    else:
+        parsed = edits
 
-    if not isinstance(edits, list):
+    if not isinstance(parsed, list):
         raise ModelRetry(
-            f"Expected a JSON array of edits, got {type(edits).__name__}. "
+            f"Expected a JSON array of edits, got {type(parsed).__name__}. "
             f'Use the format: [{{"old": "old text", "new": "new text"}}]'
         )
 
-    if not edits:
+    if not parsed:
         raise ModelRetry("Edits array is empty — provide at least one edit.")
 
-    for i, edit in enumerate(edits):
+    for i, edit in enumerate(parsed):
         if not isinstance(edit, dict):
             raise ModelRetry(
                 f"Edit #{i + 1} is not an object (got {type(edit).__name__}). "

--- a/src/ossature/templates/files/config.template
+++ b/src/ossature/templates/files/config.template
@@ -16,11 +16,14 @@ runner = "pytest"
 coverage = true
 coverage_threshold = 80.0
 
+[audit]
+# max_fix_cycles = 3                                   # audit → fix → re-audit cycles per spec
+
 [build]
 # setup = "uv init && uv sync"                         # Run before first task
 # verify = "uv run python -m py_compile"               # Override default verify
 # test = "uv run pytest"                               # Override default test
-# max_fix_attempts = 3
+# max_fix_attempts = 3                                 # verify-fail → fix → re-verify per task
 
 [llm]
 model = "anthropic:claude-sonnet-4-6"
@@ -32,4 +35,5 @@ model = "anthropic:claude-sonnet-4-6"
 # interface = "anthropic:claude-sonnet-4-6"
 # fixer = "anthropic:claude-sonnet-4-6"       # requires tool-use support
 # retries = 3                                      # structured output retries per agent call
+# tool_retries = 5                                  # tool call retries (edit_file, etc.)
 # ollama_base_url = "http://localhost:11434/v1"  # only needed for ollama: models

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import patch
 
 from click.testing import CliRunner
 from helpers import make_spec_task_plan, patch_all_agents, run_in_project, write_smd
@@ -356,11 +355,7 @@ class TestIncrementalReplan:
         # Edit only AUTH
         write_smd(project_dir, "AUTH", "Auth Module v2", overview="New auth.")
 
-        with (
-            patch_all_agents({"AUTH": AUTH_PLAN_V2, "API": API_PLAN}),
-            patch("ossature.cli.commands.audit.questionary.confirm") as mock_confirm,
-        ):
-            mock_confirm.return_value.ask.return_value = True
+        with patch_all_agents({"AUTH": AUTH_PLAN_V2, "API": API_PLAN}):
             result = run_in_project(runner, project_dir, ["audit", "--replan"])
 
         assert result.exit_code == 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -91,6 +91,7 @@ model = "anthropic:claude-sonnet-4-6"
         assert sample_config.llm.fixer is None
         assert sample_config.llm.ollama_base_url == DEFAULT_OLLAMA_BASE_URL
         assert sample_config.llm.retries == 3
+        assert sample_config.llm.tool_retries == 5
 
     def test_llm_model_for_falls_back_to_default(self):
         llm = LLMConfig(model="test:default-model")

--- a/tests/unit/test_fixer.py
+++ b/tests/unit/test_fixer.py
@@ -13,10 +13,9 @@ from ossature.audit.fixer import (
     _verify_spec_parses,
 )
 from ossature.cli.commands.audit import (
-    MAX_FIX_CYCLES,
     _build_amd_file_map,
     _build_spec_file_map,
-    _has_fixable_findings,
+    _has_fixable_errors,
 )
 from ossature.models.audit import (
     AuditFinding,
@@ -242,12 +241,25 @@ class TestBuildCrossSpecFindingPrompt:
         assert "specs/api.smd" not in prompt
 
 
-class TestHasFixableFindings:
+class TestHasFixableErrors:
     def test_no_findings(self) -> None:
         report = SpecAuditReport(findings=[])
-        assert _has_fixable_findings(report) is False
+        assert _has_fixable_errors(report) is False
 
-    def test_findings_with_suggestions(self) -> None:
+    def test_error_with_suggestion(self) -> None:
+        report = SpecAuditReport(
+            findings=[
+                AuditFinding(
+                    severity=Severity.ERROR,
+                    location="Overview",
+                    issue="Ambiguous",
+                    suggestion="Clarify the requirement",
+                )
+            ]
+        )
+        assert _has_fixable_errors(report) is True
+
+    def test_warning_with_suggestion_is_not_fixable(self) -> None:
         report = SpecAuditReport(
             findings=[
                 AuditFinding(
@@ -258,22 +270,35 @@ class TestHasFixableFindings:
                 )
             ]
         )
-        assert _has_fixable_findings(report) is True
+        assert _has_fixable_errors(report) is False
 
-    def test_findings_without_suggestions(self) -> None:
+    def test_error_without_suggestion(self) -> None:
         report = SpecAuditReport(
             findings=[
                 AuditFinding(
-                    severity=Severity.INFO,
+                    severity=Severity.ERROR,
                     location="Overview",
                     issue="Minor note",
                     suggestion="",
                 )
             ]
         )
-        assert _has_fixable_findings(report) is False
+        assert _has_fixable_errors(report) is False
 
-    def test_cross_spec_report(self) -> None:
+    def test_cross_spec_error(self) -> None:
+        report = CrossSpecAuditReport(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.ERROR,
+                    specs=["AUTH", "API"],
+                    issue="Mismatch",
+                    suggestion="Align the types",
+                )
+            ]
+        )
+        assert _has_fixable_errors(report) is True
+
+    def test_cross_spec_warning_is_not_fixable(self) -> None:
         report = CrossSpecAuditReport(
             findings=[
                 CrossSpecFinding(
@@ -284,9 +309,9 @@ class TestHasFixableFindings:
                 )
             ]
         )
-        assert _has_fixable_findings(report) is True
+        assert _has_fixable_errors(report) is False
 
-    def test_mixed_findings(self) -> None:
+    def test_mixed_findings_only_counts_errors(self) -> None:
         report = SpecAuditReport(
             findings=[
                 AuditFinding(
@@ -301,9 +326,15 @@ class TestHasFixableFindings:
                     issue="Has fix",
                     suggestion="Do this",
                 ),
+                AuditFinding(
+                    severity=Severity.ERROR,
+                    location="C",
+                    issue="Real error",
+                    suggestion="Fix it",
+                ),
             ]
         )
-        assert _has_fixable_findings(report) is True
+        assert _has_fixable_errors(report) is True
 
 
 class TestBuildSpecFileMap:
@@ -350,9 +381,9 @@ class TestBuildAmdFileMap:
         assert result == {"AUTH": ["auth.amd", "auth-models.amd"]}
 
 
-class TestMaxFixCycles:
-    def test_max_fix_cycles_is_positive(self) -> None:
-        assert MAX_FIX_CYCLES > 0
+class TestAuditConfigDefaults:
+    def test_max_fix_cycles_default(self) -> None:
+        from ossature.config.loader import AuditConfig
 
-    def test_max_fix_cycles_is_reasonable(self) -> None:
-        assert MAX_FIX_CYCLES <= 5
+        cfg = AuditConfig()
+        assert cfg.max_fix_cycles == 3


### PR DESCRIPTION
**What does this change?**

Makes `ossature audit` non-interactive by default. The old flow prompted 3 times per spec per fix cycle ("Print full report?", "Continue?" (default No), "Auto-fix?") which meant pressing Enter at the wrong prompt would abort the entire audit halfway through, felt like a trap.

Now the default path has zero prompts. Audit auto-fixes errors silently, prints a consolidated findings table at the end, and exits 1 if errors remain. Warnings and info are reported but never auto-fixed. Three new flags control the behavior: `--interactive` to restore prompting with better defaults, `--no-fix` to skip fixing entirely, and `--errors-ok` to suppress the exit 1.

The `edit_file` tool parameter changed from a raw JSON string to `list[dict[str, str]]` so pydantic-ai validates the structure directly from the LLM's tool call. This eliminates the JSON-within-JSON encoding that less capable models (gemini-flash, ollama locals) consistently failed at. The fixer error handler now also extracts the root cause from the chained exception so users see why edits failed instead of just "exceeded max retries".

Config changes: added `tool_retries` in `[llm]` config section (default 5, separate from retries which is for structured output), and a new `[audit]` section with `max_fix_cycles` (default 3) so the audit fix loop budget is configurable like everything else.

**How was it tested?**

Added new tests and updated relevant existing ones. 