### PR TITLE
Increase test coverage and fix missing cycle detection in validate

### DIFF
--- a/src/ossature/cli/commands/audit.py
+++ b/src/ossature/cli/commands/audit.py
@@ -35,6 +35,7 @@ from ossature.audit.planner import (
     remove_orphaned_output_files,
     write_plan,
 )
+from ossature.cli.commands.validate import ValidationError, validate_specs
 from ossature.cli.decorators import requires_llm
 from ossature.config.loader import ConfigError, OssatureConfig, load_config
 from ossature.models.amd import AMDSpec
@@ -50,9 +51,6 @@ from ossature.parsers.amd import AMDParseError, parse_amd_file
 from ossature.parsers.smd import SMDParseError, parse_smd_file
 
 FixMode = str  # "auto" | "interactive" | "none"
-
-
-class ValidationError(Exception): ...
 
 
 SEVERITY_STYLES: dict[Severity, tuple[str, str]] = {
@@ -322,33 +320,6 @@ def generate_and_write_interfaces(
             console.log(f"  Written to [bold]{filepath}[/bold] ({source})")
 
 
-def quick_validate(
-    smd_files: list[Path], amd_files: list[Path]
-) -> tuple[list[SMDSpec], list[AMDSpec]]:
-    parsed_smds: list[SMDSpec] = []
-    parsed_amds: list[AMDSpec] = []
-
-    for smd_file in smd_files:
-        parsed_smds.append(parse_smd_file(smd_file))
-
-    for amd_file in amd_files:
-        parsed_amds.append(parse_amd_file(amd_file))
-
-    smd_spec_ids = [smd.spec_id for smd in parsed_smds]
-
-    for smd in parsed_smds:
-        for dep in smd.depends:
-            if dep not in smd_spec_ids:
-                raise ValidationError
-
-    if parsed_amds:
-        for amd in parsed_amds:
-            if amd.spec_id not in smd_spec_ids:
-                raise ValidationError
-
-    return parsed_smds, parsed_amds
-
-
 @requires_llm
 def run_audit(
     config_path: Path,
@@ -378,9 +349,9 @@ def run_audit(
             return
 
         try:
-            parsed_smds, parsed_amds = quick_validate(smd_files=smd_files, amd_files=amd_files)
+            parsed_smds, parsed_amds = validate_specs(smd_files, amd_files)
         except SMDParseError, AMDParseError, ValidationError:
-            console.log("[red] Specs invalid. Run: `ossature validate` to check errors.")
+            console.log("[red] Specs invalid. Run `ossature validate` to see errors.")
             raise SystemExit(1) from None
 
         console.log("[green]✓ specs valid")

--- a/src/ossature/cli/commands/validate.py
+++ b/src/ossature/cli/commands/validate.py
@@ -8,8 +8,8 @@ from ossature.config.loader import ConfigError, load_config
 from ossature.models.amd import AMDSpec
 from ossature.models.shared import Status
 from ossature.models.smd import Priority, SMDSpec
-from ossature.parsers.amd import AMDParseError, parse_amd_file
-from ossature.parsers.smd import SMDParseError, parse_smd_file
+from ossature.parsers.amd import parse_amd_file
+from ossature.parsers.smd import parse_smd_file
 
 STATUS_STYLE: dict[Status, str] = {
     Status.DRAFT: "dim",
@@ -25,6 +25,76 @@ PRIORITY_STYLE: dict[Priority, str] = {
     Priority.MEDIUM: "blue",
     Priority.LOW: "dim",
 }
+
+
+class ValidationError(Exception):
+    pass
+
+
+_WHITE, _GRAY, _BLACK = 0, 1, 2
+
+
+def _detect_cycle(dep_map: dict[str, list[str]]) -> list[str] | None:
+    color: dict[str, int] = dict.fromkeys(dep_map, _WHITE)
+    parent: dict[str, str | None] = dict.fromkeys(dep_map, None)
+
+    def dfs(node: str) -> list[str] | None:
+        color[node] = _GRAY
+        for dep in dep_map.get(node, []):
+            if dep not in color:
+                continue
+            if color[dep] == _GRAY:
+                cycle = [dep, node]
+                cur = node
+                p = parent[cur]
+                while p is not None and p != dep:
+                    cycle.append(p)
+                    cur = p
+                    p = parent[cur]
+                cycle.reverse()
+                return cycle
+            if color[dep] == _WHITE:
+                parent[dep] = node
+                result = dfs(dep)
+                if result:
+                    return result
+        color[node] = _BLACK
+        return None
+
+    for node in dep_map:
+        if color[node] == _WHITE:
+            result = dfs(node)
+            if result:
+                return result
+    return None
+
+
+def validate_specs(
+    smd_files: list[Path], amd_files: list[Path]
+) -> tuple[list[SMDSpec], list[AMDSpec]]:
+    parsed_smds = [parse_smd_file(f) for f in smd_files]
+    parsed_amds = [parse_amd_file(f) for f in amd_files]
+
+    smd_spec_ids = [smd.spec_id for smd in parsed_smds]
+
+    for smd in parsed_smds:
+        for dep in smd.depends:
+            if dep not in smd_spec_ids:
+                raise ValidationError(
+                    f"Spec {smd.spec_id} has dependency {dep} that doesn't exist."
+                )
+
+    dep_map = {smd.spec_id: list(smd.depends) for smd in parsed_smds}
+    cycle = _detect_cycle(dep_map)
+    if cycle:
+        cycle_str = " -> ".join([*cycle, cycle[0]])
+        raise ValidationError(f"Circular dependency detected: {cycle_str}")
+
+    for amd in parsed_amds:
+        if amd.spec_id not in smd_spec_ids:
+            raise ValidationError(f"Architecture for spec {amd.spec_id} that doesn't exist.")
+
+    return parsed_smds, parsed_amds
 
 
 def print_validation_summary(
@@ -94,6 +164,9 @@ def run_validate(
     verbose: bool,
     console: Console,
 ) -> None:
+    from ossature.parsers.amd import AMDParseError
+    from ossature.parsers.smd import SMDParseError
+
     try:
         config = load_config(config_path)
     except ConfigError as e:
@@ -102,7 +175,6 @@ def run_validate(
         console.print(f"[red]Error:[/] {escape(str(e))}")
         raise SystemExit(1) from None
 
-    _conf_file = config.root / "ossature.toml"
     smd_files = list(config.spec_path.glob("**/*.smd"))
     amd_files = list(config.spec_path.glob("**/*.amd"))
 
@@ -110,86 +182,59 @@ def run_validate(
         console.print("[yellow]No spec files found.[/]")
         return
 
-    if verbose:
-        console.print(f"Validating {len(smd_files)} SMD(s)")
-
-    parsed_smds = []
-    parsed_amds = []
-
-    for smd_file in smd_files:
-        smd_filename = str(smd_file).replace(str(config.root), ".")
-        if verbose:
-            console.print(f" {smd_filename} ", end="")
+    if not verbose:
         try:
-            smd = parse_smd_file(smd_file)
-            parsed_smds.append(smd)
-
-            if verbose:
-                console.print("[green]✓")
-        except SMDParseError as e:
-            if verbose:
-                console.print(f"[red]x[/] - {len(e.errors)} error(s)")
-            else:
-                console.print(smd_filename)
-                console.print(f"[red]Validation Error:[/] {len(e.errors)} error(s)")
-
-            for error in e.errors:
-                console.print(f"  - {error}")
-
+            parsed_smds, parsed_amds = validate_specs(smd_files, amd_files)
+        except (SMDParseError, AMDParseError, ValidationError) as e:
+            console.print(f"[red]Validation Error:[/] {e}")
             raise SystemExit(1) from None
 
-    if verbose:
         console.print()
-        console.print(f"Validating {len(amd_files)} AMD(s)")
+        console.print("[green]✓[/green] All checks passed")
+        print_validation_summary(console, parsed_smds=parsed_smds, parsed_amds=parsed_amds)
+        return
 
-    for amd_file in amd_files:
-        amd_filename = str(amd_file).replace(str(config.root), ".")
-        if verbose:
-            console.print(f" {amd_filename} ", end="")
+    # Verbose path: show per-file progress, then delegate cross-reference checks
+    console.print(f"Validating {len(smd_files)} SMD(s)")
+
+    parsed_smds = []
+    for smd_file in smd_files:
+        smd_filename = str(smd_file).replace(str(config.root), ".")
+        console.print(f" {smd_filename} ", end="")
         try:
-            amd = parse_amd_file(amd_file)
-            parsed_amds.append(amd)
-
-            if verbose:
-                console.print("[green]✓")
-        except AMDParseError as e:
-            if verbose:
-                console.print(f"[red]x[/] - {len(e.errors)} error(s)")
-            else:
-                console.print(smd_filename)
-                console.print(f"[red]Validation Error:[/] {len(e.errors)} error(s)")
-
+            parsed_smds.append(parse_smd_file(smd_file))
+            console.print("[green]✓")
+        except SMDParseError as e:
+            console.print(f"[red]x[/] - {len(e.errors)} error(s)")
             for error in e.errors:
                 console.print(f"  - {error}")
-
             raise SystemExit(1) from None
 
     console.print()
-    console.print("Cross-reference spec dependencies: ", end="")
+    console.print(f"Validating {len(amd_files)} AMD(s)")
 
-    # Cross reference parsed spec ids
-    smd_spec_ids = [smd.spec_id for smd in parsed_smds]
+    parsed_amds = []
+    for amd_file in amd_files:
+        amd_filename = str(amd_file).replace(str(config.root), ".")
+        console.print(f" {amd_filename} ", end="")
+        try:
+            parsed_amds.append(parse_amd_file(amd_file))
+            console.print("[green]✓")
+        except AMDParseError as e:
+            console.print(f"[red]x[/] - {len(e.errors)} error(s)")
+            for error in e.errors:
+                console.print(f"  - {error}")
+            raise SystemExit(1) from None
 
-    for smd in parsed_smds:
-        for dep in smd.depends:
-            if dep not in smd_spec_ids:
-                console.print("[red]x")
-                console.print(f" Spec {smd.spec_id} has dependency {dep} that doesn't exist.")
-                raise SystemExit(1)
+    # Cross-reference and cycle checks (reuse validate_specs logic on already-parsed specs)
+    console.print()
+    console.print("Cross-reference checks: ", end="")
+    try:
+        validate_specs(smd_files, amd_files)
+        console.print("[green]✓ all checks passed")
+    except ValidationError as e:
+        console.print("[red]x")
+        console.print(f" {e}")
+        raise SystemExit(1) from None
 
-    console.print("[green]✓ all dependency spec IDs resolve")
-
-    # Cross reference architecture specs
-    if parsed_amds:
-        console.print()
-        console.print("Cross-reference architecture for specs: ", end="")
-        for amd in parsed_amds:
-            if amd.spec_id not in smd_spec_ids:
-                console.print("[red]x")
-                console.print(f" Architecture for a spec {amd.spec_id} that doesn't exist.")
-                raise SystemExit(1)
-
-    console.print("[green]✓ spec ids resolve")
-
-    # Summary
     print_validation_summary(console, parsed_smds=parsed_smds, parsed_amds=parsed_amds)

--- a/tests/integration/test_clean.py
+++ b/tests/integration/test_clean.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ossature.cli.main import cli
+
+
+class TestCleanCommand:
+    def _run(self, runner: CliRunner, project_dir: Path, args: list[str] | None = None):
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            return runner.invoke(cli, args or ["clean"])
+        finally:
+            os.chdir(old_cwd)
+
+    def test_nothing_to_clean(self, runner: CliRunner, project_dir: Path):
+        result = self._run(runner, project_dir)
+        assert result.exit_code == 0
+        assert "Nothing to clean" in result.output
+
+    def test_removes_ossature_dir(self, runner: CliRunner, project_dir: Path):
+        ossature_dir = project_dir / ".ossature"
+        ossature_dir.mkdir()
+        (ossature_dir / "plan.toml").write_text("data")
+
+        with patch("ossature.cli.commands.clean.questionary") as mock_q:
+            mock_q.confirm.return_value.ask.return_value = True
+            result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert not ossature_dir.exists()
+        assert "reset complete" in result.output
+
+    def test_decline_confirmation_exits(self, runner: CliRunner, project_dir: Path):
+        ossature_dir = project_dir / ".ossature"
+        ossature_dir.mkdir()
+
+        with patch("ossature.cli.commands.clean.questionary") as mock_q:
+            mock_q.confirm.return_value.ask.return_value = False
+            result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert ossature_dir.exists()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,7 +1,9 @@
+import os
 from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
+from helpers import write_smd
 
 from ossature.cli.main import cli
 from ossature.templates.manager import TemplateResult
@@ -49,3 +51,40 @@ class TestInitCmd:
             assert result.exit_code == 1
             assert "Something broke" in result.output
             assert "Error" in result.output
+
+
+class TestMutualExclusiveFlags:
+    def _run(self, runner: CliRunner, project_dir: Path, args: list[str]):
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            return runner.invoke(cli, args)
+        finally:
+            os.chdir(old_cwd)
+
+    def test_audit_interactive_and_no_fix(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Auth")
+        result = self._run(runner, project_dir, ["audit", "--interactive", "--no-fix"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+
+    def test_retry_from_and_only(self, runner: CliRunner, project_dir: Path):
+        result = self._run(runner, project_dir, ["retry", "--from", "001", "--only", "002"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+
+    def test_build_step_and_auto(self, runner: CliRunner, project_dir: Path):
+        result = self._run(runner, project_dir, ["build", "--step", "--auto"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+
+    def test_build_skip_failures_without_auto(self, runner: CliRunner, project_dir: Path):
+        result = self._run(runner, project_dir, ["build", "--skip-failures"])
+        assert result.exit_code == 1
+        assert "--auto" in result.output
+
+    def test_audit_rejects_invalid_specs(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "A", "Module A", depends="NONEXISTENT")
+        result = self._run(runner, project_dir, ["audit"])
+        assert result.exit_code == 1
+        assert "invalid" in result.output.lower()

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from helpers import run_in_project, write_smd
+
+from ossature.parsers.amd import parse_amd_file
+from ossature.parsers.smd import parse_smd_file
+
+
+class TestNewSmdCommand:
+    def test_creates_smd_file(self, runner: CliRunner, project_dir: Path):
+        result = run_in_project(runner, project_dir, ["new", "my-feature"])
+
+        assert result.exit_code == 0
+        assert (project_dir / "specs" / "my-feature.smd").exists()
+        assert "Summary" in result.output
+
+    def test_smd_file_has_correct_spec_id(self, runner: CliRunner, project_dir: Path):
+        run_in_project(runner, project_dir, ["new", "my-feature"])
+
+        content = (project_dir / "specs" / "my-feature.smd").read_text()
+        assert "@id: MY_FEATURE" in content
+
+    def test_smd_file_is_parseable(self, runner: CliRunner, project_dir: Path):
+        run_in_project(runner, project_dir, ["new", "my-feature"])
+
+        spec = parse_smd_file(project_dir / "specs" / "my-feature.smd")
+        assert spec.spec_id == "MY_FEATURE"
+        assert spec.title == "My Feature"
+
+    def test_smd_summary_shows_counts(self, runner: CliRunner, project_dir: Path):
+        result = run_in_project(runner, project_dir, ["new", "my-feature"])
+
+        assert "goal(s)" in result.output
+        assert "requirement(s)" in result.output
+        assert "constraint(s)" in result.output
+        assert "example(s)" in result.output
+
+
+class TestNewAmdCommand:
+    def test_creates_amd_file(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, spec_id="AUTH", title="Auth")
+
+        with patch("ossature.cli.commands.new.ask_spec_id", return_value="AUTH"):
+            result = run_in_project(runner, project_dir, ["new", "my-arch", "-t", "amd"])
+
+        assert result.exit_code == 0
+        assert (project_dir / "specs" / "my-arch.amd").exists()
+
+    def test_amd_file_is_parseable(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, spec_id="AUTH", title="Auth")
+
+        with patch("ossature.cli.commands.new.ask_spec_id", return_value="AUTH"):
+            run_in_project(runner, project_dir, ["new", "my-arch", "-t", "amd"])
+
+        spec = parse_amd_file(project_dir / "specs" / "my-arch.amd")
+        assert spec.spec_id == "AUTH"
+        assert spec.title == "Architecture: My Arch"

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -1,0 +1,109 @@
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+from conftest import make_plan, make_task
+
+from ossature.audit.planner import write_plan
+from ossature.cli.main import cli
+from ossature.models.plan import TaskStatus
+
+
+class TestStatusCommand:
+    def _run(self, runner, project_dir, args=None):
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            return runner.invoke(cli, args or ["status"])
+        finally:
+            os.chdir(old_cwd)
+
+    def test_no_plan_shows_message(self, runner: CliRunner, project_dir: Path):
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "No build plan" in result.output
+
+    def test_single_spec_all_pending(self, runner: CliRunner, project_dir: Path):
+        plan = make_plan(
+            [
+                make_task("1", "AUTH"),
+                make_task("2", "AUTH"),
+                make_task("3", "AUTH"),
+            ]
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "3" in result.output
+
+    def test_mixed_status(self, runner: CliRunner, project_dir: Path):
+        plan = make_plan(
+            [
+                make_task("1", "AUTH", status=TaskStatus.DONE),
+                make_task("2", "AUTH", status=TaskStatus.FAILED),
+                make_task("3", "AUTH", status=TaskStatus.PENDING),
+            ]
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "AUTH" in result.output
+        assert "3" in result.output
+
+    def test_all_done_shows_checkmark(self, runner: CliRunner, project_dir: Path):
+        plan = make_plan(
+            [
+                make_task("1", "AUTH", status=TaskStatus.DONE),
+                make_task("2", "AUTH", status=TaskStatus.DONE),
+            ]
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "✓" in result.output
+
+    def test_failed_task_shows_retry_hint(self, runner: CliRunner, project_dir: Path):
+        plan = make_plan(
+            [
+                make_task("1", "AUTH", status=TaskStatus.DONE),
+                make_task("2", "AUTH", status=TaskStatus.FAILED),
+            ]
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "ossature retry" in result.output
+
+    def test_multi_spec_status(self, runner: CliRunner, project_dir: Path):
+        plan = make_plan(
+            [
+                make_task("1", "AUTH", status=TaskStatus.DONE),
+                make_task("2", "API", status=TaskStatus.PENDING),
+            ]
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "AUTH" in result.output
+        assert "API" in result.output

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -1,0 +1,261 @@
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+from helpers import run_in_project, write_smd
+
+from ossature.cli.commands.validate import _detect_cycle
+from ossature.cli.main import cli
+
+MINIMAL_AMD = """\
+# Architecture: {title}
+
+@spec: {spec_id}
+@status: draft
+
+## Overview
+
+Some overview text.
+
+## Components
+
+### ComponentName
+
+@path: src/component.py
+
+Component description.
+
+**Interface:**
+
+```python
+def do_something() -> None: ...
+```
+"""
+
+
+class TestValidateCommand:
+    def test_validates_single_smd(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "Validated" in result.output
+
+    def test_validates_smd_with_amd(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        amd_path = project_dir / "specs" / "auth.amd"
+        amd_path.write_text(MINIMAL_AMD.format(title="Auth Architecture", spec_id="AUTH"))
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "Validated" in result.output
+        assert "1" in result.output  # 1 SMD
+        assert "AMD" in result.output
+
+    def test_no_spec_files_prints_warning(self, runner: CliRunner, project_dir: Path):
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "No spec files" in result.output
+
+    def test_invalid_smd_exits_with_error(self, runner: CliRunner, project_dir: Path):
+        (project_dir / "specs" / "broken.smd").write_text("not valid")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "error" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_invalid_amd_exits_with_error(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        (project_dir / "specs" / "auth.amd").write_text("not valid amd")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "error" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_missing_dependency_exits_with_error(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module", depends="NONEXISTENT")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "doesn't exist" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_amd_referencing_nonexistent_spec(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        amd_path = project_dir / "specs" / "ghost.amd"
+        amd_path.write_text(MINIMAL_AMD.format(title="Ghost Architecture", spec_id="GHOST"))
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "doesn't exist" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_multi_spec_with_valid_depends(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        write_smd(project_dir, "API", "API Module", depends="AUTH")
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "Validated" in result.output
+
+    def test_verbose_output(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        result = run_in_project(runner, project_dir, ["-v", "validate"])
+
+        assert result.exit_code == 0
+        assert "Validating" in result.output
+
+    def test_verbose_with_amd(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        amd_path = project_dir / "specs" / "auth.amd"
+        amd_path.write_text(MINIMAL_AMD.format(title="Auth Arch", spec_id="AUTH"))
+
+        result = run_in_project(runner, project_dir, ["-v", "validate"])
+
+        assert result.exit_code == 0
+        assert "Validating 1 AMD" in result.output
+        assert "✓" in result.output
+
+    def test_verbose_invalid_smd_shows_details(self, runner: CliRunner, project_dir: Path):
+        (project_dir / "specs" / "broken.smd").write_text("not valid")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["-v", "validate"])
+            assert result.exit_code == 1
+            assert "error(s)" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_verbose_invalid_amd_shows_details(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Auth")
+        (project_dir / "specs" / "auth.amd").write_text("not valid")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["-v", "validate"])
+            assert result.exit_code == 1
+            assert "error(s)" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_verbose_missing_dep_exits_with_error(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "AUTH", "Auth", depends="NONEXISTENT")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["-v", "validate"])
+            assert result.exit_code == 1
+            assert "doesn't exist" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_circular_dependency_two_specs(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "A", "Module A", depends="B")
+        write_smd(project_dir, "B", "Module B", depends="A")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "Circular dependency" in result.output
+            assert "A" in result.output
+            assert "B" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_circular_dependency_three_specs(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "A", "Module A", depends="B")
+        write_smd(project_dir, "B", "Module B", depends="C")
+        write_smd(project_dir, "C", "Module C", depends="A")
+
+        old_cwd = os.getcwd()
+        os.chdir(project_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "Circular dependency" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+    def test_no_cycle_passes(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "A", "Module A")
+        write_smd(project_dir, "B", "Module B", depends="A")
+        write_smd(project_dir, "C", "Module C", depends="A, B")
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+    def test_config_not_found_exits_with_error(self, runner: CliRunner, temp_dir: Path):
+        old_cwd = os.getcwd()
+        os.chdir(temp_dir)
+        try:
+            result = runner.invoke(cli, ["validate"])
+            assert result.exit_code == 1
+            assert "Error" in result.output
+        finally:
+            os.chdir(old_cwd)
+
+
+class TestDetectCycle:
+    def test_no_deps(self):
+        assert _detect_cycle({"A": [], "B": []}) is None
+
+    def test_linear_chain(self):
+        assert _detect_cycle({"A": [], "B": ["A"], "C": ["B"]}) is None
+
+    def test_two_node_cycle(self):
+        result = _detect_cycle({"A": ["B"], "B": ["A"]})
+        assert result is not None
+        assert "A" in result
+        assert "B" in result
+
+    def test_three_node_cycle(self):
+        result = _detect_cycle({"A": ["B"], "B": ["C"], "C": ["A"]})
+        assert result is not None
+        assert len(result) == 3
+
+    def test_self_cycle(self):
+        result = _detect_cycle({"A": ["A"]})
+        assert result is not None
+        assert "A" in result
+
+    def test_cycle_with_uninvolved_specs(self):
+        result = _detect_cycle({"X": [], "A": ["B"], "B": ["A"], "Y": ["X"]})
+        assert result is not None
+        assert "X" not in result
+
+    def test_empty_graph(self):
+        assert _detect_cycle({}) is None
+
+    def test_dep_not_in_graph(self):
+        assert _detect_cycle({"A": ["EXTERNAL"]}) is None

--- a/tests/unit/test_audit_io.py
+++ b/tests/unit/test_audit_io.py
@@ -1,0 +1,216 @@
+from pathlib import Path
+
+from conftest import make_config
+
+from ossature.audit.audit import (
+    load_cross_spec_audit_data,
+    load_spec_audit_data,
+    save_audit_report,
+    save_cross_spec_audit_data,
+    save_spec_audit_data,
+)
+from ossature.audit.manifest import create_manifest, read_manifest, write_manifest
+from ossature.models.audit import (
+    AuditFinding,
+    CrossSpecAuditReport,
+    CrossSpecFinding,
+    Manifest,
+    Severity,
+    SpecAuditReport,
+)
+
+
+class TestSpecAuditDataIO:
+    def test_save_and_load_roundtrip(self, temp_dir: Path):
+        audit_dir = temp_dir / "audits"
+        report = SpecAuditReport(
+            findings=[
+                AuditFinding(
+                    severity=Severity.ERROR,
+                    location="L5",
+                    issue="Missing returns section",
+                    suggestion="Add a returns section",
+                ),
+                AuditFinding(
+                    severity=Severity.WARNING,
+                    location="L10",
+                    issue="Vague requirement",
+                    suggestion="Be more specific",
+                ),
+            ]
+        )
+
+        save_spec_audit_data(report, "AUTH", audit_dir)
+        loaded = load_spec_audit_data("AUTH", audit_dir)
+
+        assert loaded is not None
+        assert len(loaded.findings) == 2
+        assert loaded.findings[0].severity == Severity.ERROR
+        assert loaded.findings[0].location == "L5"
+        assert loaded.findings[0].issue == "Missing returns section"
+        assert loaded.findings[1].severity == Severity.WARNING
+
+    def test_load_nonexistent_returns_none(self, temp_dir: Path):
+        audit_dir = temp_dir / "audits"
+        audit_dir.mkdir()
+
+        result = load_spec_audit_data("NONEXISTENT", audit_dir)
+
+        assert result is None
+
+    def test_creates_audit_dir(self, temp_dir: Path):
+        audit_dir = temp_dir / "nested" / "audits"
+        report = SpecAuditReport(findings=[])
+
+        save_spec_audit_data(report, "TEST", audit_dir)
+
+        assert audit_dir.exists()
+        assert (audit_dir / "TEST.json").exists()
+
+
+class TestCrossSpecAuditDataIO:
+    def test_save_and_load_roundtrip(self, temp_dir: Path):
+        audit_dir = temp_dir / "audits"
+        report = CrossSpecAuditReport(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.ERROR,
+                    specs=["AUTH", "USERS"],
+                    issue="Inconsistent user ID type",
+                    suggestion="Align on UUID",
+                ),
+            ]
+        )
+
+        save_cross_spec_audit_data(report, audit_dir)
+        loaded = load_cross_spec_audit_data(audit_dir)
+
+        assert loaded is not None
+        assert len(loaded.findings) == 1
+        assert loaded.findings[0].specs == ["AUTH", "USERS"]
+        assert loaded.findings[0].issue == "Inconsistent user ID type"
+
+    def test_load_nonexistent_returns_none(self, temp_dir: Path):
+        audit_dir = temp_dir / "audits"
+        audit_dir.mkdir()
+
+        result = load_cross_spec_audit_data(audit_dir)
+
+        assert result is None
+
+    def test_empty_findings_roundtrip(self, temp_dir: Path):
+        audit_dir = temp_dir / "audits"
+        report = CrossSpecAuditReport(findings=[])
+
+        save_cross_spec_audit_data(report, audit_dir)
+        loaded = load_cross_spec_audit_data(audit_dir)
+
+        assert loaded is not None
+        assert loaded.findings == []
+
+
+class TestSaveAuditReport:
+    def test_writes_markdown_file(self, temp_dir: Path):
+        filename = temp_dir / "report.md"
+        spec_reports = {"AUTH": SpecAuditReport(findings=[])}
+
+        save_audit_report(spec_reports, None, "test-project", filename)
+
+        assert filename.exists()
+        content = filename.read_text()
+        assert content.startswith("# Audit Report:")
+
+    def test_includes_spec_findings(self, temp_dir: Path):
+        filename = temp_dir / "report.md"
+        finding = AuditFinding(
+            severity=Severity.ERROR,
+            location="L5",
+            issue="Bad requirement",
+            suggestion="Fix it",
+        )
+        spec_reports = {"AUTH": SpecAuditReport(findings=[finding])}
+
+        save_audit_report(spec_reports, None, "test-project", filename)
+
+        content = filename.read_text()
+        assert "ERROR" in content
+        assert "Bad requirement" in content
+
+    def test_includes_cross_spec_findings(self, temp_dir: Path):
+        filename = temp_dir / "report.md"
+        cross_report = CrossSpecAuditReport(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.WARNING,
+                    specs=["AUTH", "USERS"],
+                    issue="Type mismatch",
+                    suggestion="Use same type",
+                ),
+            ]
+        )
+
+        save_audit_report({}, cross_report, "test-project", filename)
+
+        content = filename.read_text()
+        assert "Cross-Spec Findings" in content
+        assert "Type mismatch" in content
+
+    def test_no_findings_message(self, temp_dir: Path):
+        filename = temp_dir / "report.md"
+        spec_reports = {"AUTH": SpecAuditReport(findings=[])}
+
+        save_audit_report(spec_reports, None, "test-project", filename)
+
+        content = filename.read_text()
+        assert "No findings" in content
+
+    def test_creates_parent_dirs(self, temp_dir: Path):
+        filename = temp_dir / "nested" / "deep" / "report.md"
+        spec_reports = {"AUTH": SpecAuditReport(findings=[])}
+
+        save_audit_report(spec_reports, None, "test-project", filename)
+
+        assert filename.exists()
+
+
+class TestManifest:
+    def test_create_manifest_checksums_files(self, temp_dir: Path):
+        config = make_config(temp_dir)
+        spec_dir = temp_dir / "specs"
+        spec_dir.mkdir()
+        smd = spec_dir / "auth.smd"
+        smd.write_text("some content")
+        (temp_dir / "ossature.toml").write_text('[llm]\nmodel = "test:x"\n')
+
+        manifest = create_manifest(config, [smd], [])
+
+        assert len(manifest.sources) > 0
+        assert any("auth.smd" in key for key in manifest.sources)
+        assert "ossature.toml" in manifest.sources
+        for value in manifest.sources.values():
+            assert value.startswith("sha256:")
+
+    def test_write_and_read_roundtrip(self, temp_dir: Path):
+        manifest = Manifest(
+            sources={"./specs/auth.smd": "sha256:abc123", "ossature.toml": "sha256:def456"}
+        )
+        filepath = temp_dir / "manifest.toml"
+
+        write_manifest(manifest, filepath)
+        loaded = read_manifest(filepath)
+
+        assert loaded is not None
+        assert loaded.sources == manifest.sources
+
+    def test_read_nonexistent_returns_none(self, temp_dir: Path):
+        result = read_manifest(temp_dir / "nonexistent.toml")
+
+        assert result is None
+
+    def test_read_invalid_toml_returns_none(self, temp_dir: Path):
+        filepath = temp_dir / "bad.toml"
+        filepath.write_text("{{{{not valid toml!!")
+
+        result = read_manifest(filepath)
+
+        assert result is None

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,0 +1,112 @@
+from pydantic_ai.exceptions import AgentRunError, ModelHTTPError, UsageLimitExceeded
+
+from ossature.cli.decorators import (
+    _collect_required_env_vars,
+    _describe_llm_error,
+    _format_llm_error_body,
+    _get_provider_prefix,
+)
+
+
+class TestGetProviderPrefix:
+    def test_anthropic(self):
+        assert _get_provider_prefix("anthropic:claude-sonnet-4-6") == "anthropic"
+
+    def test_ollama(self):
+        assert _get_provider_prefix("ollama:deepseek-coder") == "ollama"
+
+    def test_no_colon(self):
+        assert _get_provider_prefix("plain-model") is None
+
+    def test_multiple_colons(self):
+        assert _get_provider_prefix("openai:gpt:4") == "openai"
+
+    def test_empty_string(self):
+        assert _get_provider_prefix("") is None
+
+
+class TestCollectRequiredEnvVars:
+    def test_single_model(self, temp_dir):
+        config = temp_dir / "ossature.toml"
+        config.write_text('[llm]\nmodel = "anthropic:claude-sonnet-4-6"\n')
+        result = _collect_required_env_vars(config)
+        assert result == {"ANTHROPIC_API_KEY": "Anthropic"}
+
+    def test_multiple_models(self, temp_dir):
+        config = temp_dir / "ossature.toml"
+        config.write_text('[llm]\nmodel = "anthropic:claude-sonnet-4-6"\naudit = "openai:gpt-4o"\n')
+        result = _collect_required_env_vars(config)
+        assert result == {"ANTHROPIC_API_KEY": "Anthropic", "OPENAI_API_KEY": "OpenAI"}
+
+    def test_ollama_model_no_env_var(self, temp_dir):
+        config = temp_dir / "ossature.toml"
+        config.write_text('[llm]\nmodel = "ollama:deepseek-coder"\n')
+        result = _collect_required_env_vars(config)
+        assert result == {}
+
+    def test_missing_config(self, temp_dir):
+        result = _collect_required_env_vars(temp_dir / "nonexistent.toml")
+        assert result == {}
+
+    def test_no_llm_section(self, temp_dir):
+        config = temp_dir / "ossature.toml"
+        config.write_text('[project]\nname = "test"\n')
+        result = _collect_required_env_vars(config)
+        assert result == {}
+
+
+class TestDescribeLlmError:
+    def test_402_credits(self):
+        e = ModelHTTPError(status_code=402, model_name="claude")
+        summary, suggestion = _describe_llm_error(e)
+        assert "credits" in summary.lower()
+        assert "retry" in suggestion.lower()
+
+    def test_429_rate_limit(self):
+        e = ModelHTTPError(status_code=429, model_name="claude")
+        summary, _suggestion = _describe_llm_error(e)
+        assert "rate" in summary.lower()
+
+    def test_500_server(self):
+        e = ModelHTTPError(status_code=500, model_name="claude")
+        summary, _suggestion = _describe_llm_error(e)
+        assert "server" in summary.lower()
+
+    def test_generic_4xx(self):
+        e = ModelHTTPError(status_code=400, model_name="claude")
+        summary, suggestion = _describe_llm_error(e)
+        assert "400" in summary
+        assert "configuration" in suggestion.lower()
+
+    def test_usage_limit(self):
+        e = UsageLimitExceeded("too many")
+        summary, _ = _describe_llm_error(e)
+        assert "limit" in summary.lower()
+
+    def test_generic_error(self):
+        e = AgentRunError("something broke")
+        summary, suggestion = _describe_llm_error(e)
+        assert "something broke" in summary
+        assert "retry" in suggestion.lower()
+
+
+class TestFormatLlmErrorBody:
+    def test_dict_with_error_message(self):
+        e = ModelHTTPError(
+            status_code=400,
+            model_name="claude",
+            body={"error": {"message": "details"}},
+        )
+        assert _format_llm_error_body(e) == "details"
+
+    def test_string_body(self):
+        e = ModelHTTPError(status_code=500, model_name="claude", body="error text")
+        assert _format_llm_error_body(e) == "error text"
+
+    def test_no_body(self):
+        e = ModelHTTPError(status_code=429, model_name="claude")
+        assert _format_llm_error_body(e) is None
+
+    def test_non_http_error(self):
+        e = AgentRunError("something")
+        assert _format_llm_error_body(e) is None

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ossature.templates.manager import TemplateManager
+from ossature.templates.manager import TemplateManager, TemplateResult
 
 
 class TestTemplateManager:
@@ -12,3 +12,39 @@ class TestTemplateManager:
         assert (temp_dir / ".gitignore").exists()
         assert (temp_dir / "ossature.toml").exists()
         assert (temp_dir / "specs").is_dir()
+
+    def test_init_project_skips_existing_config(self, temp_dir: Path):
+        (temp_dir / "ossature.toml").write_text("existing")
+        manager = TemplateManager(temp_dir)
+        result = manager.init_project(name="test-project")
+        assert any("ossature.toml" in str(p) for p in result.skipped)
+        assert (temp_dir / "ossature.toml").read_text() == "existing"
+
+    def test_init_project_skips_existing_gitignore(self, temp_dir: Path):
+        (temp_dir / ".gitignore").write_text("existing")
+        manager = TemplateManager(temp_dir)
+        result = manager.init_project(name="test-project")
+        assert any(".gitignore" in str(p) for p in result.skipped)
+
+    def test_init_project_custom_dirs(self, temp_dir: Path):
+        manager = TemplateManager(temp_dir)
+        result = manager.init_project(name="test", spec_dir="my-specs", context_dir="my-ctx")
+        assert result.success
+        assert (temp_dir / "my-specs").is_dir()
+        assert (temp_dir / "my-ctx").is_dir()
+
+    def test_init_project_config_contains_name(self, temp_dir: Path):
+        manager = TemplateManager(temp_dir)
+        manager.init_project(name="my-cool-project")
+        content = (temp_dir / "ossature.toml").read_text()
+        assert "my-cool-project" in content
+
+
+class TestTemplateResult:
+    def test_success_false_on_errors(self):
+        result = TemplateResult(created=[], skipped=[], errors=["something failed"])
+        assert result.success is False
+
+    def test_success_true_no_errors(self):
+        result = TemplateResult(created=[], skipped=[], errors=[])
+        assert result.success is True


### PR DESCRIPTION
**What does this change?**

Validate didn't properly handle catching circular dependencies in spec graph. Added DFS-based cycle detection to validate_specs().

This also refactored audit's quick_validate to call the same function instead of duplicating the checks.

The main change here is adding tests for CLI commands and helpers that had zero or low coverage, things like validate, status, new, clean, the decorator helpers, audit I/O, and CLI flags.

Increased coverage to 63%.

**How was it tested?**
