### PR TITLE
quick fix: don't ignore .ossature metadata dir by default

### DIFF
--- a/src/ossature/templates/files/gitignore.template
+++ b/src/ossature/templates/files/gitignore.template
@@ -1,5 +1,2 @@
-# Ossature
-.ossature/
-
 # OS
 .DS_Store

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from helpers import write_smd
 
 from ossature.cli.main import cli
-from ossature.templates.manager import TemplateResult
+from ossature.templates.manager import TemplateLoader, TemplateResult
 
 
 class TestInitCmd:
@@ -36,6 +36,20 @@ class TestInitCmd:
 
             assert result.exit_code == 0
             assert "Skipped" in result.output
+
+    def test_init_gitignore_matches_template(self, runner: CliRunner, temp_dir: Path):
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            runner.invoke(cli, ["init", "proj"])
+            actual = (Path("proj") / ".gitignore").read_text()
+            expected = TemplateLoader.get("gitignore")
+            assert actual == expected
+
+    def test_init_config_matches_template(self, runner: CliRunner, temp_dir: Path):
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            runner.invoke(cli, ["init", "proj"])
+            actual = (Path("proj") / "ossature.toml").read_text()
+            expected = TemplateLoader.get("config").format(name="proj")
+            assert actual == expected
 
     def test_init_shows_errors(self, runner: CliRunner, temp_dir: Path):
         error_result = TemplateResult(created=[], skipped=[], errors=["Something broke"])


### PR DESCRIPTION
**What does this change?**

Remove `.ossature` metadata dir from default `gitignore` template file for new ossature projects. It makes more sense to think that this dir should be stored along with the code in a git repo to maintain history. 

**How was it tested?**

Added test cases to ensure generated files during init match the templates that should be used exactly.