### PR TITLE
Fix unhandled JSONDecodeError when API returns malformed HTTP response

### DIFF
--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import re
 import shlex
 import shutil
@@ -420,6 +421,15 @@ def _run_with_retry(
                 return agent.run_sync(
                     prompt, deps=deps, usage_limits=UsageLimits(request_limit=200)
                 )
+            except json.JSONDecodeError:
+                if attempt >= max_retries - 1:
+                    raise
+                delay = base_delay * (2**attempt)
+                console.log(
+                    f"    [yellow]Malformed API response, retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 1}/{max_retries})[/yellow]"
+                )
+                time.sleep(delay)
             except ModelHTTPError as e:
                 if e.status_code != 429 or attempt >= max_retries - 1:
                     raise

--- a/src/ossature/cli/decorators.py
+++ b/src/ossature/cli/decorators.py
@@ -241,5 +241,19 @@ def requires_llm(fn: Callable[..., Any]) -> Callable[..., Any]:
             console = kwargs.get("console") or Console()
             _print_llm_error(console, e)
             raise SystemExit(1) from None
+        except json.JSONDecodeError:
+            console = kwargs.get("console") or Console()
+            console.print()
+            console.print(
+                Panel(
+                    "The API returned a malformed response that could not be parsed.\n"
+                    "This is usually a transient issue. Wait a moment and retry.",
+                    title="[bold red]LLM Error[/bold red]",
+                    border_style="red",
+                    expand=False,
+                    box=box.ROUNDED,
+                )
+            )
+            raise SystemExit(1) from None
 
     return wrapper

--- a/src/ossature/shared/llm.py
+++ b/src/ossature/shared/llm.py
@@ -1,3 +1,6 @@
+import json
+import logging
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -5,6 +8,11 @@ from pydantic_ai import Agent, capture_run_messages
 from pydantic_ai.exceptions import AgentRunError
 from pydantic_ai.messages import ModelMessage, ModelRequest, RetryPromptPart
 from pydantic_ai.run import AgentRunResult
+
+logger = logging.getLogger(__name__)
+
+TRANSPORT_RETRY_ATTEMPTS = 3
+TRANSPORT_RETRY_BASE_DELAY = 2.0
 
 
 def _classify_failure(messages: list[ModelMessage]) -> str:
@@ -66,14 +74,28 @@ def run_agent_sync[OutputT](
     **run_kwargs: Any,
 ) -> AgentRunResult[OutputT]:
     """Wrap a single agent.run_sync() call with context for better error reporting."""
-    with capture_run_messages() as messages:
-        try:
-            return agent.run_sync(prompt, **run_kwargs)
-        except AgentRunError as e:
-            raise LLMRunError(
-                operation=operation,
-                model_name=model_name,
-                spec_id=spec_id,
-                classification=_classify_failure(messages),
-                original=e,
-            ) from e
+    for attempt in range(TRANSPORT_RETRY_ATTEMPTS):
+        with capture_run_messages() as messages:
+            try:
+                return agent.run_sync(prompt, **run_kwargs)
+            except json.JSONDecodeError:
+                if attempt >= TRANSPORT_RETRY_ATTEMPTS - 1:
+                    raise
+                delay = TRANSPORT_RETRY_BASE_DELAY * (2**attempt)
+                logger.warning(
+                    "Malformed API response during %s, retrying in %.0fs (attempt %d/%d)",
+                    operation,
+                    delay,
+                    attempt + 1,
+                    TRANSPORT_RETRY_ATTEMPTS,
+                )
+                time.sleep(delay)
+            except AgentRunError as e:
+                raise LLMRunError(
+                    operation=operation,
+                    model_name=model_name,
+                    spec_id=spec_id,
+                    classification=_classify_failure(messages),
+                    original=e,
+                ) from e
+    raise RuntimeError("Unreachable")  # pragma: no cover

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,3 +1,6 @@
+import json
+
+import pytest
 from pydantic_ai.exceptions import AgentRunError, ModelHTTPError, UsageLimitExceeded
 
 from ossature.cli.decorators import (
@@ -5,6 +8,7 @@ from ossature.cli.decorators import (
     _describe_llm_error,
     _format_llm_error_body,
     _get_provider_prefix,
+    requires_llm,
 )
 
 
@@ -110,3 +114,16 @@ class TestFormatLlmErrorBody:
     def test_non_http_error(self):
         e = AgentRunError("something")
         assert _format_llm_error_body(e) is None
+
+
+class TestRequiresLlmJsonDecodeError:
+    def test_catches_json_decode_error(self, tmp_path):
+        config_path = tmp_path / "ossature.toml"
+        config_path.write_text('[llm]\nmodel = "ollama:test"\n')
+
+        @requires_llm
+        def failing_fn(config_path, **kwargs):
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+        with pytest.raises(SystemExit, match="1"):
+            failing_fn(config_path)

--- a/tests/unit/test_llm_error_handling.py
+++ b/tests/unit/test_llm_error_handling.py
@@ -1,5 +1,7 @@
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
+import pytest
 from conftest import make_task
 from pydantic_ai.exceptions import AgentRunError, ModelHTTPError, UsageLimitExceeded
 
@@ -8,6 +10,7 @@ from ossature.build.builder import (
     _format_llm_error_body,
     _is_structural_tool_error,
     _print_llm_error,
+    _run_with_retry,
 )
 
 
@@ -147,3 +150,35 @@ class TestPrintLlmError:
         assert "AUTH task 003" in log_args
 
         console.print.assert_called()
+
+
+class TestRunWithRetryJsonDecode:
+    @patch("ossature.build.builder.time.sleep")
+    def test_retries_on_json_decode_error(self, mock_sleep):
+        mock_result = MagicMock()
+        agent = MagicMock()
+        agent.run_sync.side_effect = [
+            json.JSONDecodeError("Expecting value", "", 0),
+            mock_result,
+        ]
+        console = MagicMock()
+        deps = MagicMock()
+
+        result = _run_with_retry(agent, "prompt", deps, console, max_retries=3, base_delay=1.0)
+
+        assert result is mock_result
+        assert agent.run_sync.call_count == 2
+        mock_sleep.assert_called_once()
+        console.log.assert_called_once()
+
+    @patch("ossature.build.builder.time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        agent = MagicMock()
+        agent.run_sync.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        console = MagicMock()
+        deps = MagicMock()
+
+        with pytest.raises(json.JSONDecodeError):
+            _run_with_retry(agent, "prompt", deps, console, max_retries=3, base_delay=1.0)
+
+        assert agent.run_sync.call_count == 3

--- a/tests/unit/test_llm_run_error.py
+++ b/tests/unit/test_llm_run_error.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic_ai.exceptions import AgentRunError
@@ -185,3 +186,28 @@ class TestRunAgentSync:
         with pytest.raises(LLMRunError) as exc_info:
             run_agent_sync(agent, "prompt", operation="test")
         assert exc_info.value.model_name is None
+
+    @patch("ossature.shared.llm.time.sleep")
+    def test_retries_on_json_decode_error(self, mock_sleep):
+        mock_result = MagicMock()
+        agent = MagicMock()
+        agent.run_sync.side_effect = [
+            json.JSONDecodeError("Expecting value", "", 0),
+            mock_result,
+        ]
+
+        result = run_agent_sync(agent, "prompt", operation="test")
+
+        assert result is mock_result
+        assert agent.run_sync.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("ossature.shared.llm.time.sleep")
+    def test_raises_json_decode_error_after_max_retries(self, mock_sleep):
+        agent = MagicMock()
+        agent.run_sync.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+
+        with pytest.raises(json.JSONDecodeError):
+            run_agent_sync(agent, "prompt", operation="test")
+
+        assert agent.run_sync.call_count == 3


### PR DESCRIPTION
Resolve #32 

**What does this change?**

`json.JSONDecodeError` wasn't caught anywhere, so a truncated API response from an LLM provider would just crash with a traceback. This adds retry-with-backoff for it in `run_agent_sync` and the builder's `_run_with_retry`, and a catch for the `@requires_llm` decorator that tells the user to retry instead.

**How was it tested?**

Added unit tests for the retry-on-JSONDecodeError path in both `run_agent_sync` and `_run_with_retry`, covering successful retry and exhausted retries. Also added a test for the `@requires_llm` decorator catching `JSONDecodeError` and raising `SystemExit`.