### PR TITLE
feat: track and display LLM token usage and cost per task in build and audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ typecheck:
 	uv run mypy src
 
 test:
-	uv run pytest tests/ -v
+	uv run pytest tests/ -v $(ARGS)
 
 test-cov:
 	uv run pytest tests/ --cov=src/ossature --cov-report=term-missing --cov-report=html --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,12 @@ line-length = 100
 target-version = "py314"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "B", "S", "SIM", "PT", "RUF", "C4", "PIE"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "S", "SIM", "PT", "RUF", "C4", "PIE", "PLC0415"]
 ignore = ["S602", "S110", "S310"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101"]
+"src/**/*.py" = ["PLC0415"]
 
 [tool.mypy]
 python_version = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "click>=8.3.1",
     "content-types>=0.3.0",
+    "genai-prices>=0.0.51",
     "pydantic>=2.12.5",
     "pydantic-ai>=1.62.0",
     "questionary>=2.1.1",
@@ -55,6 +56,9 @@ build-backend = "uv_build"
 
 [tool.uv]
 exclude-newer = "7 days"
+
+# mistralai 2.x removed the Mistral class that pydantic-ai imports
+constraint-dependencies = ["mistralai<2"]
 
 [tool.ruff]
 line-length = 100

--- a/src/ossature/audit/audit.py
+++ b/src/ossature/audit/audit.py
@@ -11,7 +11,7 @@ from ossature.config.loader import OssatureConfig
 from ossature.models.amd import AMDSpec
 from ossature.models.audit import CrossSpecAuditReport, SpecAuditReport
 from ossature.models.smd import SMDSpec
-from ossature.shared.llm import run_agent_sync
+from ossature.shared.llm import UsageTracker, run_agent_sync
 
 
 def _read_numbered(path: Path) -> str:
@@ -27,6 +27,7 @@ def audit_spec(
     smd_path: Path,
     spec_id: str,
     amd_paths: list[Path] | None = None,
+    tracker: UsageTracker | None = None,
 ) -> SpecAuditReport:
     model = config.llm.model_for("audit")
     agent = Agent(
@@ -52,6 +53,7 @@ def audit_spec(
         operation="spec audit",
         model_name=model,
         spec_id=spec_id,
+        tracker=tracker,
     )
 
     return result.output
@@ -61,6 +63,7 @@ def audit_cross_specs(
     config: OssatureConfig,
     parsed_smds: list[SMDSpec],
     parsed_amds: list[AMDSpec] | None = None,
+    tracker: UsageTracker | None = None,
 ) -> CrossSpecAuditReport:
     """
     Audit interfaces between interdependent specs.
@@ -143,6 +146,7 @@ def audit_cross_specs(
         audit_input,
         operation="cross-spec audit",
         model_name=model,
+        tracker=tracker,
     )
 
     return result.output

--- a/src/ossature/audit/context.py
+++ b/src/ossature/audit/context.py
@@ -4,7 +4,7 @@ from ossature.config.loader import OssatureConfig
 from ossature.models.audit import Brief
 from ossature.models.smd import SMDSpec
 from ossature.renderer.smd import render_smd
-from ossature.shared.llm import run_agent_sync
+from ossature.shared.llm import UsageTracker, run_agent_sync
 
 
 def format_smd_specs_overviews(specs: list[SMDSpec]) -> str:
@@ -49,7 +49,11 @@ def format_smd_specs_overviews(specs: list[SMDSpec]) -> str:
     return "\n\n".join(formatted_parts)
 
 
-def generate_project_brief(config: OssatureConfig, parsed_smds: list[SMDSpec]) -> Brief:
+def generate_project_brief(
+    config: OssatureConfig,
+    parsed_smds: list[SMDSpec],
+    tracker: UsageTracker | None = None,
+) -> Brief:
     system_prompt = (
         "<role>\n"
         "You are a technical writer creating a project summary for an LLM code generation system.\n"
@@ -87,12 +91,17 @@ def generate_project_brief(config: OssatureConfig, parsed_smds: list[SMDSpec]) -
         user_prompt,
         operation="project brief generation",
         model_name=model,
+        tracker=tracker,
     )
 
     return Brief(brief=result.output)
 
 
-def generate_spec_briefs(config: OssatureConfig, parsed_smds: list[SMDSpec]) -> dict[str, Brief]:
+def generate_spec_briefs(
+    config: OssatureConfig,
+    parsed_smds: list[SMDSpec],
+    tracker: UsageTracker | None = None,
+) -> dict[str, Brief]:
     system_prompt = (
         "<role>\n"
         "You are a technical writer creating a module "
@@ -125,6 +134,7 @@ def generate_spec_briefs(config: OssatureConfig, parsed_smds: list[SMDSpec]) -> 
             operation="spec brief generation",
             model_name=model,
             spec_id=smd.spec_id,
+            tracker=tracker,
         )
 
         briefs[smd.spec_id] = Brief(brief=result.output)

--- a/src/ossature/audit/fixer.py
+++ b/src/ossature/audit/fixer.py
@@ -11,6 +11,7 @@ from ossature.audit.prompts import SPEC_FIXER_SYSTEM_PROMPT
 from ossature.config.loader import OssatureConfig
 from ossature.models.audit import AuditFinding, CrossSpecFinding, Severity
 from ossature.shared import FileEdit, apply_edits
+from ossature.shared.llm import UsageTracker
 
 
 def _format_fix_error(e: Exception) -> str:
@@ -166,8 +167,10 @@ def fix_spec_findings(
     config: OssatureConfig,
     console: Console,
     status: Status,
+    tracker: UsageTracker | None = None,
 ) -> list[str]:
     agent = _create_fixer_agent(config)
+    fixer_model = config.llm.model_for("fixer")
     all_edited: list[str] = []
 
     has_errors_or_warnings = any(f.severity in (Severity.ERROR, Severity.WARNING) for f in findings)
@@ -189,7 +192,9 @@ def fix_spec_findings(
         )
 
         try:
-            agent.run_sync(prompt, deps=fix_ctx)
+            result = agent.run_sync(prompt, deps=fix_ctx)
+            if tracker is not None:
+                tracker.add(result.usage(), model_name=fixer_model)
 
             # Verify file still parses after edit
             if not _verify_spec_parses(full_path):
@@ -215,8 +220,10 @@ def fix_cross_spec_findings(
     config: OssatureConfig,
     console: Console,
     status: Status,
+    tracker: UsageTracker | None = None,
 ) -> list[str]:
     agent = _create_fixer_agent(config)
+    fixer_model = config.llm.model_for("fixer")
     all_edited: list[str] = []
 
     has_errors_or_warnings = any(f.severity in (Severity.ERROR, Severity.WARNING) for f in findings)
@@ -247,7 +254,9 @@ def fix_cross_spec_findings(
         )
 
         try:
-            agent.run_sync(prompt, deps=fix_ctx)
+            result = agent.run_sync(prompt, deps=fix_ctx)
+            if tracker is not None:
+                tracker.add(result.usage(), model_name=fixer_model)
 
             # Verify all edited files still parse
             revert = False

--- a/src/ossature/audit/interfaces.py
+++ b/src/ossature/audit/interfaces.py
@@ -5,7 +5,7 @@ from ossature.config.loader import OssatureConfig
 from ossature.models.amd import AMDSpec
 from ossature.models.smd import SMDSpec
 from ossature.renderer.smd import render_smd
-from ossature.shared.llm import run_agent_sync
+from ossature.shared.llm import UsageTracker, run_agent_sync
 
 
 def extract_interface_from_amds(
@@ -63,6 +63,7 @@ def infer_interface_from_smd(
     config: OssatureConfig,
     smd: SMDSpec,
     dependency_interfaces: dict[str, str] | None = None,
+    tracker: UsageTracker | None = None,
 ) -> str:
     model = config.llm.model_for("interface")
     agent = Agent(
@@ -92,6 +93,7 @@ def infer_interface_from_smd(
         operation="interface inference",
         model_name=model,
         spec_id=smd.spec_id,
+        tracker=tracker,
     )
 
     return f"# Interface: {smd.spec_id}\n\n@source: llm\n\n{result.output}"

--- a/src/ossature/audit/planner.py
+++ b/src/ossature/audit/planner.py
@@ -18,7 +18,7 @@ from ossature.models.plan import Plan, PlanMeta, PlanTask, SpecTaskPlan, TaskSta
 from ossature.models.smd import SMDSpec
 from ossature.renderer.amd import render_amd
 from ossature.renderer.smd import render_smd
-from ossature.shared.llm import run_agent_sync
+from ossature.shared.llm import UsageTracker, run_agent_sync
 
 
 def generate_spec_plan(
@@ -27,6 +27,7 @@ def generate_spec_plan(
     amds: list[AMDSpec] | None,
     audit_report: SpecAuditReport | None,
     context_inventory: list[str] | None = None,
+    tracker: UsageTracker | None = None,
 ) -> SpecTaskPlan:
     model = config.llm.model_for("planner")
     agent = Agent(
@@ -88,6 +89,7 @@ def generate_spec_plan(
         operation="plan generation",
         model_name=model,
         spec_id=smd.spec_id,
+        tracker=tracker,
     )
 
     return result.output
@@ -190,6 +192,7 @@ def generate_plan(
     spec_reports: dict[str, SpecAuditReport],
     changed_spec_ids: set[str] | None = None,
     existing_plan: Plan | None = None,
+    tracker: UsageTracker | None = None,
 ) -> tuple[Plan, dict[str, str] | None]:
     spec_plans: dict[str, SpecTaskPlan] = {}
 
@@ -220,6 +223,7 @@ def generate_plan(
                 amds,
                 audit_report,
                 context_inventory=context_inventory or None,
+                tracker=tracker,
             )
             spec_plans[spec_id] = spec_plan
 

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -34,6 +34,7 @@ from ossature.build.state import (
     compute_output_hash,
     get_task_created_files,
     load_state,
+    make_task_slug,
     write_state,
 )
 from ossature.config.loader import OssatureConfig
@@ -805,11 +806,6 @@ def run_verify(command: str, cwd: Path) -> tuple[bool, str]:
 
 
 # Task building
-
-
-def make_task_slug(task: PlanTask) -> str:
-    slug = task.title.lower().replace(" ", "-").replace(":", "").replace("/", "-")
-    return slug.strip("-")
 
 
 def save_task_output(

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import content_types
 import tomli_w
@@ -939,6 +939,66 @@ class TaskResult:
         return ", ".join(parts)
 
 
+class BuildBackend(Protocol):
+    def generate(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Console,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str: ...
+
+    def fix(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Console,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str: ...
+
+    def verify(self, command: str, cwd: Path) -> tuple[bool, str]: ...
+
+
+class DefaultBuildBackend:
+    def __init__(self, config: OssatureConfig) -> None:
+        self._config = config
+
+    def generate(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Console,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str:
+        agent = _create_impl_agent(self._config)
+        result = _run_with_retry(
+            agent, prompt, ctx, console, tracker=tracker, model_name=model_name
+        )
+        output: str = result.output
+        return output
+
+    def fix(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Console,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str:
+        agent = _create_fix_agent(self._config)
+        result = _run_with_retry(
+            agent, prompt, ctx, console, tracker=tracker, model_name=model_name
+        )
+        output: str = result.output
+        return output
+
+    def verify(self, command: str, cwd: Path) -> tuple[bool, str]:
+        return run_verify(command, cwd)
+
+
 def build_task(
     task: PlanTask,
     config: OssatureConfig,
@@ -946,8 +1006,10 @@ def build_task(
     console: Console,
     status: Status,
     verbose: bool = False,
+    *,
+    backend: BuildBackend | None = None,
 ) -> TaskResult:
-    impl_agent = _create_impl_agent(config)
+    backend = backend or DefaultBuildBackend(config)
 
     slug = make_task_slug(task)
     task_dir = config.metadata_path / "tasks" / f"{task.id}-{slug}"
@@ -972,10 +1034,10 @@ def build_task(
 
     # Implementation
     build_ctx.set_phase("-- generating...")
-    result = _run_with_retry(
-        impl_agent, prompt, build_ctx, console, tracker=task_usage, model_name=build_model
+    gen_output = backend.generate(
+        prompt, build_ctx, console, tracker=task_usage, model_name=build_model
     )
-    (task_dir / "response.md").write_text(result.output)
+    (task_dir / "response.md").write_text(gen_output)
 
     def _make_result(success: bool) -> TaskResult:
         return TaskResult(
@@ -994,7 +1056,7 @@ def build_task(
 
     # Verification
     build_ctx.set_phase(f"-- verifying ({task.verify})")
-    passed, verify_output = run_verify(task.verify, config.output_path)
+    passed, verify_output = backend.verify(task.verify, config.output_path)
 
     if passed:
         save_task_output(
@@ -1021,15 +1083,9 @@ def build_task(
         # Snapshot file lists to detect no-op responses
         files_before = set(build_ctx.created_files) | set(build_ctx.edited_files)
 
-        fix_agent = _create_fix_agent(config)
         try:
-            fix_result = _run_with_retry(
-                fix_agent,
-                fix_prompt,
-                build_ctx,
-                console,
-                tracker=task_usage,
-                model_name=build_model,
+            fix_output = backend.fix(
+                fix_prompt, build_ctx, console, tracker=task_usage, model_name=build_model
             )
         except AgentRunError as e:
             console.log(
@@ -1039,7 +1095,7 @@ def build_task(
             attempt += 1
             continue
 
-        (task_dir / f"fix-{attempt + 1}-response.md").write_text(fix_result.output)
+        (task_dir / f"fix-{attempt + 1}-response.md").write_text(fix_output)
 
         # Detect no-op: fixer made no file changes
         files_after = set(build_ctx.created_files) | set(build_ctx.edited_files)
@@ -1067,7 +1123,7 @@ def build_task(
                 continue
 
         build_ctx.set_phase(f"-- re-verifying ({task.verify})")
-        passed, verify_output = run_verify(task.verify, config.output_path)
+        passed, verify_output = backend.verify(task.verify, config.output_path)
         if passed:
             save_task_output(
                 task_dir, build_ctx.created_files, build_ctx.edited_files, True, verify_output

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -43,6 +43,7 @@ from ossature.models.smd import SMDSpec
 from ossature.renderer.amd import render_component, render_data_model, render_dependency
 from ossature.renderer.smd import render_example, render_requirement
 from ossature.shared import FileEdit, apply_edits
+from ossature.shared.llm import UsageTracker
 
 _MAX_NOOP_RETRIES: int = 2
 
@@ -413,14 +414,19 @@ def _run_with_retry(
     console: Console,
     max_retries: int = 5,
     base_delay: float = 30.0,
+    tracker: UsageTracker | None = None,
+    model_name: str | None = None,
 ) -> Any:
     _structural_retried = False
     for attempt in range(max_retries):
         with capture_run_messages() as messages:
             try:
-                return agent.run_sync(
+                result = agent.run_sync(
                     prompt, deps=deps, usage_limits=UsageLimits(request_limit=200)
                 )
+                if tracker is not None:
+                    tracker.add(result.usage(), model_name=model_name)
+                return result
             except json.JSONDecodeError:
                 if attempt >= max_retries - 1:
                     raise
@@ -830,6 +836,7 @@ def extract_spec_interface(
     config: OssatureConfig,
     console: Console,
     status: Status,
+    tracker: UsageTracker | None = None,
 ) -> None:
     source_files: list[tuple[str, str]] = []
     for task in plan.tasks:
@@ -851,12 +858,15 @@ def extract_spec_interface(
     status.update(f"Extracting interface: {spec_id}")
     console.log(f"  [cyan]Extracting interface for {spec_id}...[/cyan]")
 
+    model = config.llm.model_for("interface")
     agent = Agent(
-        config.llm.model_for("interface"),
+        model,
         instructions=INTERFACE_EXTRACTION_SYSTEM_PROMPT.format(language=language),
         retries=config.llm.retries,
     )
     result = agent.run_sync("\n".join(sections))
+    if tracker is not None:
+        tracker.add(result.usage(), model_name=model)
 
     interface_content = f"# Interface: {spec_id}\n\n@source: build\n\n{result.output}"
 
@@ -919,6 +929,7 @@ class TaskResult:
     elapsed: float = 0.0
     created_files: list[str] = field(default_factory=list)
     edited_files: list[str] = field(default_factory=list)
+    usage: UsageTracker = field(default_factory=UsageTracker)
 
     def summary(self) -> str:
         parts = []
@@ -928,6 +939,7 @@ class TaskResult:
         if self.total_lines:
             parts.append(f"{self.total_lines} lines")
         parts.append(f"{self.elapsed:.1f}s")
+        parts.append(self.usage.format_usage())
         return ", ".join(parts)
 
 
@@ -959,10 +971,14 @@ def build_task(
     )
 
     t0 = time.monotonic()
+    task_usage = UsageTracker()
+    build_model = config.llm.model_for("build")
 
     # Implementation
     build_ctx.set_phase("-- generating...")
-    result = _run_with_retry(impl_agent, prompt, build_ctx, console)
+    result = _run_with_retry(
+        impl_agent, prompt, build_ctx, console, tracker=task_usage, model_name=build_model
+    )
     (task_dir / "response.md").write_text(result.output)
 
     def _make_result(success: bool) -> TaskResult:
@@ -973,6 +989,7 @@ def build_task(
             elapsed=time.monotonic() - t0,
             created_files=list(build_ctx.created_files),
             edited_files=list(build_ctx.edited_files),
+            usage=task_usage,
         )
 
     if not task.verify:
@@ -1010,7 +1027,14 @@ def build_task(
 
         fix_agent = _create_fix_agent(config)
         try:
-            fix_result = _run_with_retry(fix_agent, fix_prompt, build_ctx, console)
+            fix_result = _run_with_retry(
+                fix_agent,
+                fix_prompt,
+                build_ctx,
+                console,
+                tracker=task_usage,
+                model_name=build_model,
+            )
         except AgentRunError as e:
             console.log(
                 f"    [yellow]Fixer agent error on attempt {attempt + 1}: {e.message}[/yellow]"
@@ -1339,6 +1363,7 @@ def execute_build(
     completed_before = sum(1 for t in plan.tasks if t.status == TaskStatus.DONE)
     skip_next = False
     stopped = False
+    total_usage = UsageTracker()
 
     # Load build state for input/output hash verification
     state = load_state(state_filepath)
@@ -1368,7 +1393,7 @@ def execute_build(
         if not all(t.status == TaskStatus.DONE for t in tasks_by_spec[task.spec]):
             return
         try:
-            extract_spec_interface(task.spec, plan, config, console, status)
+            extract_spec_interface(task.spec, plan, config, console, status, tracker=total_usage)
         except AgentRunError as e:
             summary, _ = _describe_llm_error(e)
             console.log(
@@ -1527,6 +1552,7 @@ def execute_build(
                 continue
 
             success = result.success
+            total_usage += result.usage
 
             if success:
                 task.status = TaskStatus.DONE
@@ -1597,6 +1623,7 @@ def execute_build(
                         status.start()
                         stopped = True
                         break
+                    total_usage += retry_result.usage
                     if retry_result.success:
                         task.status = TaskStatus.DONE
                         rebuilt_specs.add(task.spec)
@@ -1668,6 +1695,8 @@ def execute_build(
         summary.append(f"  Failed: {failed}", style="bold red")
     if skipped:
         summary.append(f"  Skipped: {skipped}", style="dim")
+    if total_usage.requests > 0:
+        summary.append(f"  LLM: {total_usage.format_usage()}", style="dim")
 
     console.print()
     console.print(

--- a/src/ossature/build/state.py
+++ b/src/ossature/build/state.py
@@ -59,10 +59,13 @@ def compute_output_hash(created_files: list[str], config: OssatureConfig) -> str
     return f"sha256:{hasher.hexdigest()}"
 
 
+def make_task_slug(task: PlanTask) -> str:
+    slug = task.title.lower().replace(" ", "-").replace(":", "").replace("/", "-")
+    return slug.strip("-")
+
+
 def get_task_created_files(task: PlanTask, tasks_dir: Path) -> list[str]:
     """Get created files for a DONE task from output.toml, falling back to task.outputs."""
-    from ossature.build.builder import make_task_slug
-
     slug = make_task_slug(task)
     output_file = tasks_dir / f"{task.id}-{slug}" / "output.toml"
     if output_file.exists():

--- a/src/ossature/cli/commands/audit.py
+++ b/src/ossature/cli/commands/audit.py
@@ -49,6 +49,7 @@ from ossature.models.audit import (
 from ossature.models.smd import SMDSpec
 from ossature.parsers.amd import AMDParseError, parse_amd_file
 from ossature.parsers.smd import SMDParseError, parse_smd_file
+from ossature.shared.llm import UsageTracker
 
 FixMode = str  # "auto" | "interactive" | "none"
 
@@ -230,6 +231,7 @@ def generate_and_write_briefs(
     config: OssatureConfig,
     parsed_smds: list[SMDSpec],
     changed_spec_ids: set[str] | None = None,
+    tracker: UsageTracker | None = None,
 ) -> None:
     config.metadata_context_path.mkdir(parents=True, exist_ok=True)
     project_brief_filepath = config.metadata_context_path / "project-brief.md"
@@ -242,7 +244,9 @@ def generate_and_write_briefs(
 
     if is_full_audit or not project_brief_filepath.exists():
         status.update("Generating project brief")
-        project_brief = generate_project_brief(config=config, parsed_smds=parsed_smds)
+        project_brief = generate_project_brief(
+            config=config, parsed_smds=parsed_smds, tracker=tracker
+        )
         with open(project_brief_filepath, "w") as f:
             f.write(project_brief.brief)
             f.flush()
@@ -256,7 +260,7 @@ def generate_and_write_briefs(
         if changed_spec_ids is not None
         else parsed_smds
     )
-    spec_brefs = generate_spec_briefs(config=config, parsed_smds=smds_to_brief)
+    spec_brefs = generate_spec_briefs(config=config, parsed_smds=smds_to_brief, tracker=tracker)
     config.metadata_context_spec_briefs_path.mkdir(parents=True, exist_ok=True)
 
     for spec_id, brief in spec_brefs.items():
@@ -276,6 +280,7 @@ def generate_and_write_interfaces(
     amd_by_spec: dict[str, list[AMDSpec]],
     changed_spec_ids: set[str],
     topo_levels: list[list[str]],
+    tracker: UsageTracker | None = None,
 ) -> None:
     config.metadata_context_interfaces_path.mkdir(parents=True, exist_ok=True)
 
@@ -306,7 +311,7 @@ def generate_and_write_interfaces(
                     dep_id: interfaces[dep_id] for dep_id in smd.depends if dep_id in interfaces
                 }
                 interface = infer_interface_from_smd(
-                    config, smd, dep_interfaces if dep_interfaces else None
+                    config, smd, dep_interfaces if dep_interfaces else None, tracker=tracker
                 )
 
             interfaces[spec_id] = interface
@@ -338,6 +343,8 @@ def run_audit(
 
         console.print(f"[red]Error:[/] {escape(str(e))}")
         raise SystemExit(1) from None
+
+    audit_usage = UsageTracker()
 
     with Status("Spec validation", console=console) as status:
         # Quick validation
@@ -464,7 +471,9 @@ def run_audit(
                     spec_amd_paths = [
                         config.spec_path / rel for rel in amd_file_map.get(smd.spec_id, [])
                     ]
-                    report = audit_spec(config, smd_path, smd.spec_id, spec_amd_paths or None)
+                    report = audit_spec(
+                        config, smd_path, smd.spec_id, spec_amd_paths or None, tracker=audit_usage
+                    )
                     save_spec_audit_data(report, smd.spec_id, audit_data_dir)
                     spec_reports[smd.spec_id] = report
                     audited_spec_ids.add(smd.spec_id)
@@ -511,6 +520,7 @@ def run_audit(
                         config=config,
                         console=console,
                         status=status,
+                        tracker=audit_usage,
                     )
 
                     if not edited:
@@ -568,7 +578,9 @@ def run_audit(
                     else:
                         status.update(f"Cross-spec audit - {config.name} v{config.version}")
 
-                    cross_spec_report = audit_cross_specs(config, parsed_smds, parsed_amds)
+                    cross_spec_report = audit_cross_specs(
+                        config, parsed_smds, parsed_amds, tracker=audit_usage
+                    )
                     save_cross_spec_audit_data(cross_spec_report, audit_data_dir)
 
                     counts = dict.fromkeys(Severity, 0)
@@ -615,6 +627,7 @@ def run_audit(
                         config=config,
                         console=console,
                         status=status,
+                        tracker=audit_usage,
                     )
 
                     if not edited:
@@ -665,7 +678,12 @@ def run_audit(
         specs_needing_briefs = audited_spec_ids | specs_missing_briefs
         if specs_needing_briefs:
             generate_and_write_briefs(
-                console, status, config, parsed_smds, changed_spec_ids=specs_needing_briefs
+                console,
+                status,
+                config,
+                parsed_smds,
+                changed_spec_ids=specs_needing_briefs,
+                tracker=audit_usage,
             )
         else:
             console.log("[yellow]Project and spec brief regeneration not required")
@@ -686,6 +704,7 @@ def run_audit(
                 amd_by_spec,
                 changed_spec_ids=specs_needing_interfaces,
                 topo_levels=graph.levels,
+                tracker=audit_usage,
             )
             status.stop()
         else:
@@ -730,6 +749,7 @@ def run_audit(
                 spec_reports=spec_reports,
                 changed_spec_ids=audited_spec_ids if use_incremental else None,
                 existing_plan=existing_plan if use_incremental else None,
+                tracker=audit_usage,
             )
 
             # Remap task directories and build state if incremental merge happened
@@ -776,6 +796,11 @@ def run_audit(
             console.print()
             console.print(f"  Review the plan:  [cyan]{plan_filepath}[/cyan]")
             console.print("  Start building:   [cyan]ossature build[/cyan]")
+            console.print()
+
+        # Print LLM usage summary
+        if audit_usage.requests > 0:
+            console.print(f"  [dim]LLM usage: {audit_usage.format_usage()}[/dim]")
             console.print()
 
         # Exit 1 if audit errors remain (unless --errors-ok)

--- a/src/ossature/shared/llm.py
+++ b/src/ossature/shared/llm.py
@@ -4,10 +4,13 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from genai_prices import Usage as GenAIUsage
+from genai_prices import calc_price
 from pydantic_ai import Agent, capture_run_messages
 from pydantic_ai.exceptions import AgentRunError
 from pydantic_ai.messages import ModelMessage, ModelRequest, RetryPromptPart
 from pydantic_ai.run import AgentRunResult
+from pydantic_ai.usage import RunUsage
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +67,89 @@ class LLMRunError(AgentRunError):
         super().__init__(original.message)
 
 
+@dataclass(slots=True)
+class UsageTracker:
+    """Accumulates token usage and cost across multiple LLM calls."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    requests: int = 0
+    model_name: str | None = None
+
+    def add(self, usage: RunUsage, model_name: str | None = None) -> None:
+        """Accumulate usage from an agent run result."""
+        self.input_tokens += usage.input_tokens or 0
+        self.output_tokens += usage.output_tokens or 0
+        self.cache_read_tokens += usage.cache_read_tokens or 0
+        self.cache_write_tokens += usage.cache_write_tokens or 0
+        self.requests += usage.requests or 0
+        if model_name and not self.model_name:
+            self.model_name = model_name
+
+    def cost(self) -> float | None:
+        """Calculate total cost in dollars. Returns None if model is unknown."""
+        if not self.model_name:
+            return None
+        # Parse "provider:model" format
+        parts = self.model_name.split(":", 1)
+        model_ref = parts[1] if len(parts) == 2 else parts[0]
+        provider_id = parts[0] if len(parts) == 2 else None
+        try:
+            kwargs: dict[str, Any] = {"model_ref": model_ref}
+            if provider_id:
+                kwargs["provider_id"] = provider_id
+            price = calc_price(
+                GenAIUsage(
+                    input_tokens=self.input_tokens,
+                    output_tokens=self.output_tokens,
+                    cache_read_tokens=self.cache_read_tokens,
+                    cache_write_tokens=self.cache_write_tokens,
+                ),
+                **kwargs,
+            )
+            return float(price.total_price)
+        except LookupError, ValueError:
+            return None
+
+    def format_cost(self) -> str:
+        """Format cost as a dollar string like '$0.03', or '?' if unknown."""
+        c = self.cost()
+        if c is None:
+            return "?"
+        if c < 0.01:
+            return f"${c:.4f}"
+        return f"${c:.2f}"
+
+    def format_tokens(self) -> str:
+        """Format token counts in a human-readable compact form like '12.3k in, 1.5k out'."""
+        return f"{_fmt_tokens(self.input_tokens)} in, {_fmt_tokens(self.output_tokens)} out"
+
+    def format_usage(self) -> str:
+        """Full human-readable usage string: tokens + cost."""
+        return f"{self.format_tokens()}, {self.format_cost()}"
+
+    def __iadd__(self, other: UsageTracker) -> UsageTracker:
+        self.input_tokens += other.input_tokens
+        self.output_tokens += other.output_tokens
+        self.cache_read_tokens += other.cache_read_tokens
+        self.cache_write_tokens += other.cache_write_tokens
+        self.requests += other.requests
+        if other.model_name and not self.model_name:
+            self.model_name = other.model_name
+        return self
+
+
+def _fmt_tokens(n: int) -> str:
+    """Format token count: 500 -> '500', 1500 -> '1.5k', 1500000 -> '1.5M'."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
 def run_agent_sync[OutputT](
     agent: Agent[Any, OutputT],
     prompt: str,
@@ -71,13 +157,17 @@ def run_agent_sync[OutputT](
     operation: str,
     model_name: str | None = None,
     spec_id: str | None = None,
+    tracker: UsageTracker | None = None,
     **run_kwargs: Any,
 ) -> AgentRunResult[OutputT]:
     """Wrap a single agent.run_sync() call with context for better error reporting."""
     for attempt in range(TRANSPORT_RETRY_ATTEMPTS):
         with capture_run_messages() as messages:
             try:
-                return agent.run_sync(prompt, **run_kwargs)
+                result = agent.run_sync(prompt, **run_kwargs)
+                if tracker is not None:
+                    tracker.add(result.usage(), model_name=model_name)
+                return result
             except json.JSONDecodeError:
                 if attempt >= TRANSPORT_RETRY_ATTEMPTS - 1:
                     raise

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,10 +4,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
+from pydantic_ai import Agent as _Agent
 from pydantic_ai.usage import RunUsage
 
 from ossature.cli.main import cli
-from ossature.models.audit import CrossSpecAuditReport, SpecAuditReport
+from ossature.models.audit import AuditFinding, CrossSpecAuditReport, SpecAuditReport
 from ossature.models.plan import PlannerTask, SpecTaskPlan
 
 # Templates
@@ -116,8 +117,12 @@ def run_in_project(runner: CliRunner, project_dir: Path, args: list[str], input:
 # Mock helpers
 
 
-def _make_mock_run_sync(spec_plans: dict[str, SpecTaskPlan]):
+def _make_mock_run_sync(
+    spec_plans: dict[str, SpecTaskPlan],
+    audit_findings: list[AuditFinding] | None = None,
+):
     _mock_usage = RunUsage(input_tokens=0, output_tokens=0, requests=1)
+    _audit_call_count: dict[str, int] = {}
 
     def mock_run_sync(self, prompt, *args, **kwargs):
         result = MagicMock()
@@ -134,6 +139,18 @@ def _make_mock_run_sync(spec_plans: dict[str, SpecTaskPlan]):
 
         # Audit agent: output_type is SpecAuditReport
         if getattr(self, "_output_type", None) is SpecAuditReport:
+            # Return findings on first call per spec, empty on re-audit
+            if audit_findings:
+                key = "audit"
+                for spec_id in spec_plans:
+                    if f"@id: {spec_id}" in prompt:
+                        key = spec_id
+                        break
+                count = _audit_call_count.get(key, 0)
+                _audit_call_count[key] = count + 1
+                if count == 0:
+                    result.output = SpecAuditReport(findings=audit_findings)
+                    return result
             result.output = SpecAuditReport(findings=[])
             return result
 
@@ -142,19 +159,32 @@ def _make_mock_run_sync(spec_plans: dict[str, SpecTaskPlan]):
             result.output = CrossSpecAuditReport(findings=[])
             return result
 
-        # Brief / interface: returns a string
+        # Brief / interface / fixer: returns a string
         result.output = "Mock brief or interface content."
         return result
 
     return mock_run_sync
 
 
+_real_agent_init = _Agent.__init__
+
+
 def _mock_agent_init(self, *args, **kwargs):
+    kwargs["defer_model_check"] = True
+    _real_agent_init(self, *args, **kwargs)
     self._output_type = kwargs.get("output_type")
 
 
-def patch_all_agents(spec_plans: dict[str, SpecTaskPlan]):
+def patch_all_agents(
+    spec_plans: dict[str, SpecTaskPlan],
+    audit_findings: list[AuditFinding] | None = None,
+):
     stack = ExitStack()
     stack.enter_context(patch("pydantic_ai.Agent.__init__", _mock_agent_init))
-    stack.enter_context(patch("pydantic_ai.Agent.run_sync", _make_mock_run_sync(spec_plans)))
+    stack.enter_context(
+        patch(
+            "pydantic_ai.Agent.run_sync",
+            _make_mock_run_sync(spec_plans, audit_findings=audit_findings),
+        )
+    )
     return stack

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
+from pydantic_ai.usage import RunUsage
 
 from ossature.cli.main import cli
 from ossature.models.audit import CrossSpecAuditReport, SpecAuditReport
@@ -116,8 +117,11 @@ def run_in_project(runner: CliRunner, project_dir: Path, args: list[str], input:
 
 
 def _make_mock_run_sync(spec_plans: dict[str, SpecTaskPlan]):
+    _mock_usage = RunUsage(input_tokens=0, output_tokens=0, requests=1)
+
     def mock_run_sync(self, prompt, *args, **kwargs):
         result = MagicMock()
+        result.usage.return_value = _mock_usage
 
         # Planner agent: output_type is SpecTaskPlan
         if getattr(self, "_output_type", None) is SpecTaskPlan:

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from click.testing import CliRunner
 from helpers import make_spec_task_plan, patch_all_agents, run_in_project, write_smd
 
+from ossature.models.audit import AuditFinding, Severity
 from ossature.models.plan import SpecTaskPlan, TaskStatus
 
 # Canned plans
@@ -74,6 +75,9 @@ class TestAuditWorkflow:
 
         # Interface was created
         assert (project_dir / ".ossature" / "context" / "interfaces" / "AUTH.md").exists()
+
+        # LLM usage summary was printed
+        assert "LLM usage:" in result.output
 
         # Plan has expected tasks
         from ossature.audit.planner import load_plan
@@ -408,3 +412,322 @@ class TestIncrementalReplan:
         assert (output_dir / "src/auth/__init__.py").exists()
         assert (output_dir / "src/api/__init__.py").exists()
         assert (output_dir / "src/api/routes.py").exists()
+
+
+class TestAuditIdempotency:
+    def test_rerun_audit_unchanged_skips_reaudit(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result1 = run_in_project(runner, project_dir, ["audit"])
+        assert result1.exit_code == 0
+
+        # Second run — nothing changed
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result2 = run_in_project(runner, project_dir, ["audit"])
+
+        assert result2.exit_code == 0
+        assert "No changes detected" in result2.output
+        assert "Plan regeneration not required" in result2.output
+
+    def test_audit_no_fix_reports_errors_without_fixing(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        error_finding = AuditFinding(
+            severity=Severity.ERROR,
+            location="Requirements",
+            issue="Vague requirement",
+            suggestion="Be more specific",
+        )
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}, audit_findings=[error_finding]):
+            result = run_in_project(runner, project_dir, ["audit", "--no-fix", "--errors-ok"])
+
+        assert result.exit_code == 0
+        # Error was reported but fixer was not invoked
+        assert "1 error(s)" in result.output
+
+    def test_audit_exits_nonzero_on_unresolved_errors(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        error_finding = AuditFinding(
+            severity=Severity.ERROR,
+            location="Requirements",
+            issue="Missing spec",
+            suggestion="Add it",
+        )
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}, audit_findings=[error_finding]):
+            result = run_in_project(runner, project_dir, ["audit", "--no-fix"])
+
+        assert result.exit_code == 1
+        assert "unresolved error(s)" in result.output
+
+    def test_audit_three_spec_chain_preserves_topo_order(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        write_smd(project_dir, "API", "API Module", depends="AUTH")
+        write_smd(project_dir, "DB", "Database Module", depends="API")
+
+        with patch_all_agents({"AUTH": AUTH_PLAN, "API": API_PLAN, "DB": DB_PLAN}):
+            result = run_in_project(runner, project_dir, ["audit"])
+
+        assert result.exit_code == 0
+
+        from ossature.audit.planner import load_plan
+
+        plan = load_plan(project_dir / ".ossature" / "plan.toml")
+        assert plan is not None
+        assert plan.meta.specs == ["AUTH", "API", "DB"]
+        assert plan.meta.total_tasks == 7
+
+        # Tasks are ordered: AUTH first, then API, then DB
+        spec_order = []
+        for t in plan.tasks:
+            if not spec_order or spec_order[-1] != t.spec:
+                spec_order.append(t.spec)
+        assert spec_order == ["AUTH", "API", "DB"]
+
+        # DB's first task depends on API's last task
+        api_tasks = [t for t in plan.tasks if t.spec == "API"]
+        db_tasks = [t for t in plan.tasks if t.spec == "DB"]
+        assert api_tasks[-1].id in db_tasks[0].depends_on
+
+
+class TestAuditFixerTracking:
+    def test_audit_with_fixable_errors_exercises_fixer_tracker(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+
+        error_finding = AuditFinding(
+            severity=Severity.ERROR,
+            location="Requirements > Core Requirement",
+            issue="Missing error handling specification",
+            suggestion="Add error cases for invalid input",
+        )
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}, audit_findings=[error_finding]):
+            result = run_in_project(runner, project_dir, ["audit", "--errors-ok"])
+
+        assert result.exit_code == 0
+        # Fixer was invoked (first audit returns error, triggers fix, re-audit is clean)
+        assert "LLM usage:" in result.output
+
+
+class TestBuildWorkflow:
+    def _run_audit(self, runner: CliRunner, project_dir: Path, spec_plans: dict[str, SpecTaskPlan]):
+        with patch_all_agents(spec_plans):
+            result = run_in_project(runner, project_dir, ["audit"])
+        assert result.exit_code == 0
+        return result
+
+    def _create_output_files(self, project_dir: Path, spec_plans: dict[str, SpecTaskPlan]):
+        """Create fake output files so extract_spec_interface can read them."""
+        output_dir = project_dir / "output"
+        for plan in spec_plans.values():
+            for task in plan.tasks:
+                for filepath in task.outputs:
+                    full_path = output_dir / filepath
+                    full_path.parent.mkdir(parents=True, exist_ok=True)
+                    full_path.write_text(f"# {filepath}\n")
+
+    def test_build_auto_exercises_tracker(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN})
+
+        # Pre-create output files so extract_spec_interface finds them
+        self._create_output_files(project_dir, {"AUTH": AUTH_PLAN})
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+        assert "Build Complete" in result.output
+        # LLM usage is shown in the build summary panel
+        assert "LLM:" in result.output
+        # Interface extraction ran for completed spec
+        assert "Extracting interface for AUTH" in result.output
+
+    def test_build_multi_spec_accumulates_usage(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        write_smd(project_dir, "API", "API Module", depends="AUTH")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN, "API": API_PLAN})
+
+        with patch_all_agents({"AUTH": AUTH_PLAN, "API": API_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+        assert "Build Complete" in result.output
+        assert "LLM:" in result.output
+
+    def test_build_marks_tasks_done_and_writes_state(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN})
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+
+        # Plan tasks should be marked DONE
+        from ossature.audit.planner import load_plan
+
+        plan = load_plan(project_dir / ".ossature" / "plan.toml")
+        assert plan is not None
+        assert all(t.status == TaskStatus.DONE for t in plan.tasks)
+
+        # State file should exist with entries for all tasks
+        from ossature.build.state import load_state
+
+        state = load_state(project_dir / ".ossature" / "state.toml")
+        for task in plan.tasks:
+            stored = state.get(task.id)
+            assert stored is not None
+            assert stored.input_hash.startswith("sha256:")
+            assert stored.output_hash.startswith("sha256:")
+
+        # Task directories should have prompt and response files
+        tasks_dir = project_dir / ".ossature" / "tasks"
+        for task in plan.tasks:
+            dirs = list(tasks_dir.glob(f"{task.id}-*"))
+            assert len(dirs) == 1
+            assert (dirs[0] / "prompt.md").exists()
+            assert (dirs[0] / "response.md").exists()
+
+    def test_build_already_done_skips(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN})
+
+        # First build
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            run_in_project(runner, project_dir, ["build", "--auto"])
+
+        # Second build — all tasks already done
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+        assert "All tasks already completed" in result.output
+
+    def test_build_force_rebuilds_completed_tasks(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN})
+
+        # First build
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            run_in_project(runner, project_dir, ["build", "--auto"])
+
+        # Force rebuild — should re-run everything
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto", "--force"])
+
+        assert result.exit_code == 0
+        assert "Build Complete" in result.output
+        assert "3 pending" in result.output
+
+    def test_build_resumes_from_partial(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        write_smd(project_dir, "API", "API Module", depends="AUTH")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN, "API": API_PLAN})
+
+        # Simulate partial build: mark AUTH tasks as done
+        from ossature.audit.planner import load_plan, write_plan
+
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan = load_plan(plan_path)
+        assert plan is not None
+        for task in plan.tasks:
+            if task.spec == "AUTH":
+                task.status = TaskStatus.DONE
+        write_plan(plan, plan_path)
+
+        # Resume build — should only run API tasks (2 pending)
+        with patch_all_agents({"AUTH": AUTH_PLAN, "API": API_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+        assert "Build Complete" in result.output
+        assert "2 pending" in result.output
+
+    def test_build_spec_filter(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        write_smd(project_dir, "API", "API Module", depends="AUTH")
+        self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN, "API": API_PLAN})
+
+        # Build only AUTH spec
+        with patch_all_agents({"AUTH": AUTH_PLAN, "API": API_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto", "--spec", "auth"])
+
+        assert result.exit_code == 0
+        assert "Build Complete" in result.output
+        assert "spec: AUTH" in result.output
+
+        # AUTH tasks should be done, API tasks should be skipped
+        from ossature.audit.planner import load_plan
+
+        plan = load_plan(project_dir / ".ossature" / "plan.toml")
+        assert plan is not None
+        auth_tasks = [t for t in plan.tasks if t.spec == "AUTH"]
+        api_tasks = [t for t in plan.tasks if t.spec == "API"]
+        assert all(t.status == TaskStatus.DONE for t in auth_tasks)
+        assert all(t.status == TaskStatus.SKIPPED for t in api_tasks)
+
+    def test_build_without_plan_fails(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "AUTH", "Authentication Module")
+        # Don't run audit — no plan exists
+
+        with patch_all_agents({"AUTH": AUTH_PLAN}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 1
+        assert "No plan found" in result.output

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from click.testing import CliRunner
 from helpers import make_spec_task_plan, patch_all_agents, run_in_project, write_smd
 
+from ossature.audit.planner import load_plan, write_plan
+from ossature.build.state import BuildState, TaskState, load_state, write_state
 from ossature.models.audit import AuditFinding, Severity
 from ossature.models.plan import SpecTaskPlan, TaskStatus
 
@@ -80,8 +82,6 @@ class TestAuditWorkflow:
         assert "LLM usage:" in result.output
 
         # Plan has expected tasks
-        from ossature.audit.planner import load_plan
-
         plan = load_plan(plan_path)
         assert plan is not None
         assert plan.meta.total_tasks == 3
@@ -100,8 +100,6 @@ class TestAuditWorkflow:
             result = run_in_project(runner, project_dir, ["audit"])
 
         assert result.exit_code == 0
-
-        from ossature.audit.planner import load_plan
 
         plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert plan is not None
@@ -129,8 +127,6 @@ class TestIncrementalReplan:
 
     def _mark_tasks_done(self, project_dir: Path):
         """Simulate a completed build by marking all tasks as done."""
-        from ossature.audit.planner import load_plan, write_plan
-
         plan_path = project_dir / ".ossature" / "plan.toml"
         plan = load_plan(plan_path)
         assert plan is not None
@@ -141,8 +137,6 @@ class TestIncrementalReplan:
 
     def _write_fake_state(self, project_dir: Path, plan):
         """Write fake state.toml entries for all tasks."""
-        from ossature.build.state import BuildState, TaskState, write_state
-
         state = BuildState()
         for task in plan.tasks:
             state.set(
@@ -197,8 +191,6 @@ class TestIncrementalReplan:
         assert "Incremental re-plan" in result.output
 
         # Load the new plan
-        from ossature.audit.planner import load_plan
-
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert new_plan is not None
 
@@ -230,8 +222,6 @@ class TestIncrementalReplan:
 
         assert result.exit_code == 0
 
-        from ossature.audit.planner import load_plan
-
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert new_plan is not None
 
@@ -259,8 +249,6 @@ class TestIncrementalReplan:
         assert result.exit_code == 0
 
         # State.toml should have remapped API task IDs
-        from ossature.build.state import load_state
-
         state = load_state(project_dir / ".ossature" / "state.toml")
 
         # Old AUTH task IDs should be gone
@@ -268,8 +256,6 @@ class TestIncrementalReplan:
             assert state.get(task_id) is None
 
         # API tasks should exist under new IDs
-        from ossature.audit.planner import load_plan
-
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         new_api_ids = [t.id for t in new_plan.tasks if t.spec == "API"]
         for task_id in new_api_ids:
@@ -304,8 +290,6 @@ class TestIncrementalReplan:
         assert not any(d.startswith("003-auth") for d in remaining_dirs)
 
         # API task dirs should exist with new IDs and preserved content
-        from ossature.audit.planner import load_plan
-
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         api_tasks = [t for t in new_plan.tasks if t.spec == "API"]
         for task in api_tasks:
@@ -338,8 +322,6 @@ class TestIncrementalReplan:
         # When all specs change, no incremental merge
         assert "Incremental re-plan" not in result.output
 
-        from ossature.audit.planner import load_plan
-
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert new_plan is not None
         # All tasks should be pending (full re-plan)
@@ -364,8 +346,6 @@ class TestIncrementalReplan:
 
         assert result.exit_code == 0
         assert "Incremental re-plan" not in result.output
-
-        from ossature.audit.planner import load_plan
 
         new_plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert new_plan is not None
@@ -489,8 +469,6 @@ class TestAuditIdempotency:
 
         assert result.exit_code == 0
 
-        from ossature.audit.planner import load_plan
-
         plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert plan is not None
         assert plan.meta.specs == ["AUTH", "API", "DB"]
@@ -600,15 +578,11 @@ class TestBuildWorkflow:
         assert result.exit_code == 0
 
         # Plan tasks should be marked DONE
-        from ossature.audit.planner import load_plan
-
         plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert plan is not None
         assert all(t.status == TaskStatus.DONE for t in plan.tasks)
 
         # State file should exist with entries for all tasks
-        from ossature.build.state import load_state
-
         state = load_state(project_dir / ".ossature" / "state.toml")
         for task in plan.tasks:
             stored = state.get(task.id)
@@ -673,8 +647,6 @@ class TestBuildWorkflow:
         self._run_audit(runner, project_dir, {"AUTH": AUTH_PLAN, "API": API_PLAN})
 
         # Simulate partial build: mark AUTH tasks as done
-        from ossature.audit.planner import load_plan, write_plan
-
         plan_path = project_dir / ".ossature" / "plan.toml"
         plan = load_plan(plan_path)
         assert plan is not None
@@ -709,8 +681,6 @@ class TestBuildWorkflow:
         assert "spec: AUTH" in result.output
 
         # AUTH tasks should be done, API tasks should be skipped
-        from ossature.audit.planner import load_plan
-
         plan = load_plan(project_dir / ".ossature" / "plan.toml")
         assert plan is not None
         auth_tasks = [t for t in plan.tasks if t.spec == "AUTH"]

--- a/tests/unit/test_build_task.py
+++ b/tests/unit/test_build_task.py
@@ -1,0 +1,215 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from pydantic_ai.exceptions import AgentRunError
+
+from ossature.build.builder import (
+    BuildContext,
+    build_task,
+)
+from ossature.models.plan import PlanTask
+from ossature.shared.llm import UsageTracker
+
+
+def _make_task(verify: str = "cargo test") -> PlanTask:
+    return PlanTask(
+        id="010",
+        spec="CORE",
+        title="Test task",
+        description="Build something",
+        outputs=["src/main.rs"],
+        depends_on=[],
+        spec_refs=[],
+        arch_refs=[],
+        verify=verify,
+    )
+
+
+def _make_config(tmp_path: Path) -> Any:
+    config = MagicMock()
+    config.output_path = tmp_path / "output"
+    config.output_path.mkdir()
+    config.metadata_path = tmp_path / ".ossature"
+    config.metadata_path.mkdir()
+    config.context_path = tmp_path / "context"
+    config.context_path.mkdir()
+    config.llm.model_for.return_value = "test-model"
+    config.build.max_fix_attempts = 3
+    return config
+
+
+class FakeBackend:
+    """Controllable backend for testing build_task orchestration."""
+
+    def __init__(
+        self,
+        verify_results: list[tuple[bool, str]] | None = None,
+        fix_side_effects: list[str | AgentRunError] | None = None,
+    ) -> None:
+        self._verify_results = list(verify_results or [(True, "")])
+        self._verify_idx = 0
+        self._fix_side_effects = list(fix_side_effects or [])
+        self._fix_idx = 0
+        self.generate_calls: list[str] = []
+        self.fix_calls: list[str] = []
+        self.verify_calls: list[str] = []
+
+    def generate(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Any,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str:
+        self.generate_calls.append(prompt)
+        return "generated code"
+
+    def fix(
+        self,
+        prompt: str,
+        ctx: BuildContext,
+        console: Any,
+        tracker: UsageTracker,
+        model_name: str,
+    ) -> str:
+        self.fix_calls.append(prompt)
+        idx = self._fix_idx
+        self._fix_idx += 1
+        if idx < len(self._fix_side_effects):
+            effect = self._fix_side_effects[idx]
+            if isinstance(effect, AgentRunError):
+                raise effect
+            # Simulate fixer creating a file so it's not detected as a no-op
+            ctx.created_files.append(f"fix-file-{idx}.rs")
+            return effect
+        ctx.created_files.append(f"fix-file-{idx}.rs")
+        return "fix applied"
+
+    def verify(self, command: str, cwd: Path) -> tuple[bool, str]:
+        self.verify_calls.append(command)
+        idx = self._verify_idx
+        self._verify_idx += 1
+        if idx < len(self._verify_results):
+            return self._verify_results[idx]
+        return self._verify_results[-1]
+
+
+def _run(
+    tmp_path: Path,
+    backend: FakeBackend,
+    verify: str = "cargo test",
+):
+    task = _make_task(verify=verify)
+    config = _make_config(tmp_path)
+    console = MagicMock()
+    status = MagicMock()
+    return build_task(task, config, "build prompt", console, status, backend=backend)
+
+
+class TestBuildTaskNoVerify:
+    def test_no_verify_returns_success(self, tmp_path: Path) -> None:
+        backend = FakeBackend()
+        task = _make_task(verify="")
+        config = _make_config(tmp_path)
+        result = build_task(task, config, "build prompt", MagicMock(), MagicMock(), backend=backend)
+        assert result.success is True
+        assert len(backend.generate_calls) == 1
+        assert len(backend.verify_calls) == 0
+        assert len(backend.fix_calls) == 0
+
+
+class TestBuildTaskVerifyPassesImmediately:
+    def test_verify_passes_first_try(self, tmp_path: Path) -> None:
+        backend = FakeBackend(verify_results=[(True, "all tests passed")])
+        result = _run(tmp_path, backend)
+        assert result.success is True
+        assert len(backend.verify_calls) == 1
+        assert len(backend.fix_calls) == 0
+
+
+class TestBuildTaskVerifyCommandError:
+    def test_invalid_verify_command_skips_fix_loop(self, tmp_path: Path) -> None:
+        backend = FakeBackend(verify_results=[(False, "bash: nimc: command not found")])
+        result = _run(tmp_path, backend)
+        assert result.success is False
+        assert len(backend.fix_calls) == 0
+
+
+class TestBuildTaskFixLoop:
+    def test_fix_then_verify_passes(self, tmp_path: Path) -> None:
+        backend = FakeBackend(
+            verify_results=[
+                (False, "error: expected ';'"),  # initial verify
+                (True, "all tests passed"),  # re-verify after fix
+            ],
+            fix_side_effects=["fixed the semicolon"],
+        )
+        result = _run(tmp_path, backend)
+        assert result.success is True
+        assert len(backend.fix_calls) == 1
+        assert len(backend.verify_calls) == 2
+
+    def test_all_fix_attempts_exhausted(self, tmp_path: Path) -> None:
+        backend = FakeBackend(
+            verify_results=[(False, "error: type mismatch")],
+            fix_side_effects=["fix 1", "fix 2", "fix 3"],
+        )
+        result = _run(tmp_path, backend)
+        assert result.success is False
+        assert len(backend.fix_calls) == 3
+        # 1 initial + 3 re-verifies
+        assert len(backend.verify_calls) == 4
+
+    def test_fix_agent_error_increments_attempt(self, tmp_path: Path) -> None:
+        backend = FakeBackend(
+            verify_results=[
+                (False, "error: undefined variable"),
+                (True, "ok"),
+            ],
+            fix_side_effects=[
+                AgentRunError("LLM error"),
+                "real fix",
+            ],
+        )
+        result = _run(tmp_path, backend)
+        assert result.success is True
+        assert len(backend.fix_calls) == 2
+
+    def test_noop_fix_retries_without_counting_attempt(self, tmp_path: Path) -> None:
+        """Fixer that makes no file changes should retry without incrementing attempt."""
+
+        class NoopThenFixBackend(FakeBackend):
+            def fix(self, prompt, ctx, console, tracker, model_name):
+                self.fix_calls.append(prompt)
+                idx = len(self.fix_calls) - 1
+                if idx == 0:
+                    # No-op: don't add any files
+                    return "I looked at it but didn't change anything"
+                # Real fix on second call
+                ctx.created_files.append("fixed.rs")
+                return "applied fix"
+
+        backend = NoopThenFixBackend(
+            verify_results=[
+                (False, "error"),
+                (True, "ok"),
+            ],
+        )
+        result = _run(tmp_path, backend)
+        assert result.success is True
+        # 2 fix calls: 1 no-op + 1 real
+        assert len(backend.fix_calls) == 2
+
+
+class TestBuildTaskArtifacts:
+    def test_prompt_and_response_written(self, tmp_path: Path) -> None:
+        backend = FakeBackend(verify_results=[(True, "ok")])
+        task = _make_task()
+        config = _make_config(tmp_path)
+        build_task(task, config, "build prompt", MagicMock(), MagicMock(), backend=backend)
+
+        task_dir = next(iter((config.metadata_path / "tasks").iterdir()))
+        assert (task_dir / "prompt.md").read_text() == "build prompt"
+        assert (task_dir / "response.md").read_text() == "generated code"

--- a/tests/unit/test_file_ownership.py
+++ b/tests/unit/test_file_ownership.py
@@ -13,6 +13,7 @@ from ossature.build.state import (
     BuildState,
     TaskState,
     compute_output_hash,
+    load_state,
     write_state,
 )
 
@@ -70,8 +71,6 @@ class TestFileOwnershipHashing:
             TaskState("sha256:in2", "sha256:out2", ["src/utils.rs"], ["src/lib.rs"]),
         )
         write_state(state, filepath)
-
-        from ossature.build.state import load_state
 
         loaded = load_state(filepath)
 

--- a/tests/unit/test_fixer.py
+++ b/tests/unit/test_fixer.py
@@ -31,6 +31,7 @@ from ossature.models.audit import (
     SpecAuditReport,
 )
 from ossature.models.shared import Status as SpecStatus
+from ossature.shared.llm import UsageTracker
 
 # -- Minimal valid spec fixtures --
 
@@ -591,6 +592,46 @@ class TestFixCrossSpecFindings:
         )
 
         assert edited == ["auth.smd"]
+
+    def test_tracks_usage_when_tracker_provided(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        (spec_dir / "auth.smd").write_text(VALID_SMD)
+
+        mock_result = mock_fixer_agent._mock_result
+
+        def fake_run_sync(prompt, *, deps, **kwargs):
+            deps.edited_files.append("auth.smd")
+            return mock_result
+
+        mock_fixer_agent.run_sync.side_effect = fake_run_sync
+
+        tracker = UsageTracker()
+        fix_cross_spec_findings(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.ERROR,
+                    specs=["AUTH"],
+                    issue="mismatch",
+                    suggestion="align",
+                ),
+            ],
+            spec_files={"AUTH": "auth.smd"},
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+            tracker=tracker,
+        )
+
+        assert tracker.requests == 1
 
 
 class TestAuditConfigDefaults:

--- a/tests/unit/test_fixer.py
+++ b/tests/unit/test_fixer.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from conftest import make_smd
 from pydantic_ai import ModelRetry
 from rich.console import Console
 from rich.status import Status
@@ -11,12 +13,16 @@ from ossature.audit.fixer import (
     _build_finding_prompt,
     _resolve_spec_sandboxed,
     _verify_spec_parses,
+    fix_cross_spec_findings,
+    fix_spec_findings,
 )
 from ossature.cli.commands.audit import (
     _build_amd_file_map,
     _build_spec_file_map,
     _has_fixable_errors,
 )
+from ossature.config.loader import AuditConfig, LLMConfig, OssatureConfig
+from ossature.models.amd import AMDSpec
 from ossature.models.audit import (
     AuditFinding,
     CrossSpecAuditReport,
@@ -24,6 +30,7 @@ from ossature.models.audit import (
     Severity,
     SpecAuditReport,
 )
+from ossature.models.shared import Status as SpecStatus
 
 # -- Minimal valid spec fixtures --
 
@@ -339,8 +346,6 @@ class TestHasFixableErrors:
 
 class TestBuildSpecFileMap:
     def test_maps_spec_ids_to_relative_paths(self, tmp_path: Path) -> None:
-        from conftest import make_smd
-
         spec_dir = tmp_path / "specs"
         spec_dir.mkdir()
 
@@ -351,8 +356,6 @@ class TestBuildSpecFileMap:
         assert result == {"AUTH": "auth.smd", "API": "api.smd"}
 
     def test_nested_spec_paths(self, tmp_path: Path) -> None:
-        from conftest import make_smd
-
         spec_dir = tmp_path / "specs"
         (spec_dir / "sub").mkdir(parents=True)
 
@@ -365,25 +368,232 @@ class TestBuildSpecFileMap:
 
 class TestBuildAmdFileMap:
     def test_maps_spec_ids_to_amd_files(self, tmp_path: Path) -> None:
-        from ossature.models.amd import AMDSpec
-        from ossature.models.shared import Status
-
         spec_dir = tmp_path / "specs"
         spec_dir.mkdir()
 
         amd_files = [spec_dir / "auth.amd", spec_dir / "auth-models.amd"]
         parsed_amds = [
-            AMDSpec(title="Auth Arch", spec_id="AUTH", status=Status.DRAFT, overview="..."),
-            AMDSpec(title="Auth Models", spec_id="AUTH", status=Status.DRAFT, overview="..."),
+            AMDSpec(title="Auth Arch", spec_id="AUTH", status=SpecStatus.DRAFT, overview="..."),
+            AMDSpec(title="Auth Models", spec_id="AUTH", status=SpecStatus.DRAFT, overview="..."),
         ]
 
         result = _build_amd_file_map(amd_files, parsed_amds, spec_dir)
         assert result == {"AUTH": ["auth.amd", "auth-models.amd"]}
 
 
+@pytest.fixture
+def fixer_config(tmp_path: Path) -> OssatureConfig:
+    return OssatureConfig(root=tmp_path, llm=LLMConfig(model="test:mock"))
+
+
+def _make_mock_agent():
+    agent = MagicMock()
+    result = MagicMock()
+    result.usage.return_value = MagicMock(
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        requests=1,
+    )
+    agent.run_sync.return_value = result
+    agent._mock_result = result
+    return agent
+
+
+@pytest.fixture
+def mock_fixer_agent():
+    with (
+        patch("ossature.audit.fixer._create_fixer_agent") as mock_create,
+        patch("ossature.audit.fixer._verify_spec_parses", return_value=True),
+    ):
+        agent = _make_mock_agent()
+        mock_create.return_value = agent
+        yield agent
+
+
+@pytest.fixture
+def mock_fixer_agent_bad_parse():
+    with (
+        patch("ossature.audit.fixer._create_fixer_agent") as mock_create,
+        patch("ossature.audit.fixer._verify_spec_parses", return_value=False),
+    ):
+        agent = _make_mock_agent()
+        mock_create.return_value = agent
+        yield agent
+
+
+class TestFixSpecFindings:
+    def test_skips_info_when_errors_present(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        spec_file = "test.smd"
+        (spec_dir / spec_file).write_text(VALID_SMD)
+
+        fix_spec_findings(
+            findings=[
+                AuditFinding(severity=Severity.ERROR, location="A", issue="bad", suggestion="fix"),
+                AuditFinding(severity=Severity.INFO, location="B", issue="note", suggestion="nah"),
+            ],
+            spec_file=spec_file,
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+        )
+
+        assert mock_fixer_agent.run_sync.call_count == 1
+
+    def test_reverts_when_parse_fails(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent_bad_parse,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        spec_file = "test.smd"
+        (spec_dir / spec_file).write_text(VALID_SMD)
+
+        edited = fix_spec_findings(
+            findings=[
+                AuditFinding(severity=Severity.ERROR, location="A", issue="bad", suggestion="fix"),
+            ],
+            spec_file=spec_file,
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+        )
+
+        assert edited == []
+        assert (spec_dir / spec_file).read_text() == VALID_SMD
+
+    def test_collects_edited_files_on_success(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        spec_file = "test.smd"
+        (spec_dir / spec_file).write_text(VALID_SMD)
+
+        mock_result = mock_fixer_agent._mock_result
+
+        def fake_run_sync(prompt, *, deps, **kwargs):
+            deps.edited_files.append(spec_file)
+            return mock_result
+
+        mock_fixer_agent.run_sync.side_effect = fake_run_sync
+
+        edited = fix_spec_findings(
+            findings=[
+                AuditFinding(severity=Severity.ERROR, location="A", issue="bad", suggestion="fix"),
+            ],
+            spec_file=spec_file,
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+        )
+
+        assert edited == [spec_file]
+
+
+class TestFixCrossSpecFindings:
+    def test_reverts_all_when_parse_fails(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent_bad_parse,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        (spec_dir / "auth.smd").write_text(VALID_SMD)
+        (spec_dir / "api.smd").write_text(VALID_SMD)
+
+        mock_result = mock_fixer_agent_bad_parse._mock_result
+
+        def fake_run_sync(prompt, *, deps, **kwargs):
+            deps.edited_files.append("auth.smd")
+            return mock_result
+
+        mock_fixer_agent_bad_parse.run_sync.side_effect = fake_run_sync
+
+        edited = fix_cross_spec_findings(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.ERROR,
+                    specs=["AUTH", "API"],
+                    issue="mismatch",
+                    suggestion="align",
+                ),
+            ],
+            spec_files={"AUTH": "auth.smd", "API": "api.smd"},
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+        )
+
+        assert edited == []
+        assert (spec_dir / "auth.smd").read_text() == VALID_SMD
+
+    def test_collects_edited_files_on_success(
+        self,
+        tmp_path: Path,
+        quiet_console: Console,
+        quiet_status: Status,
+        fixer_config,
+        mock_fixer_agent,
+    ) -> None:
+        spec_dir = tmp_path / "specs"
+        spec_dir.mkdir()
+        (spec_dir / "auth.smd").write_text(VALID_SMD)
+
+        mock_result = mock_fixer_agent._mock_result
+
+        def fake_run_sync(prompt, *, deps, **kwargs):
+            deps.edited_files.append("auth.smd")
+            return mock_result
+
+        mock_fixer_agent.run_sync.side_effect = fake_run_sync
+
+        edited = fix_cross_spec_findings(
+            findings=[
+                CrossSpecFinding(
+                    severity=Severity.ERROR,
+                    specs=["AUTH"],
+                    issue="mismatch",
+                    suggestion="align",
+                ),
+            ],
+            spec_files={"AUTH": "auth.smd"},
+            spec_dir=spec_dir,
+            config=fixer_config,
+            console=quiet_console,
+            status=quiet_status,
+        )
+
+        assert edited == ["auth.smd"]
+
+
 class TestAuditConfigDefaults:
     def test_max_fix_cycles_default(self) -> None:
-        from ossature.config.loader import AuditConfig
-
         cfg = AuditConfig()
         assert cfg.max_fix_cycles == 3

--- a/tests/unit/test_llm_error_handling.py
+++ b/tests/unit/test_llm_error_handling.py
@@ -152,6 +152,89 @@ class TestPrintLlmError:
         console.print.assert_called()
 
 
+class TestRunWithRetryAgentRunError:
+    def test_structural_error_retries_with_schema_reminder(self):
+        mock_result = MagicMock()
+        agent = MagicMock()
+        agent.run_sync.side_effect = [
+            AgentRunError("Edit #1 is missing key(s): old, new"),
+            mock_result,
+        ]
+        console = MagicMock()
+        deps = MagicMock()
+
+        with patch(
+            "ossature.build.builder._extract_last_retry_error",
+            return_value="Edit #1 is missing key(s): old, new",
+        ):
+            result = _run_with_retry(
+                agent, "original prompt", deps, console, max_retries=3, base_delay=1.0
+            )
+
+        assert result is mock_result
+        assert agent.run_sync.call_count == 2
+        # Second call should have the schema reminder appended
+        second_call_prompt = agent.run_sync.call_args_list[1][0][0]
+        assert "edit_file" in second_call_prompt
+        assert '"old"' in second_call_prompt
+        console.log.assert_called_once()
+        assert "Structural" in console.log.call_args[0][0]
+
+    def test_structural_error_only_retries_once(self):
+        agent = MagicMock()
+        agent.run_sync.side_effect = AgentRunError("missing key")
+        console = MagicMock()
+        deps = MagicMock()
+
+        with (
+            patch(
+                "ossature.build.builder._extract_last_retry_error",
+                return_value="Edit #1 is missing key(s): old",
+            ),
+            pytest.raises(AgentRunError),
+        ):
+            _run_with_retry(agent, "prompt", deps, console, max_retries=5, base_delay=1.0)
+
+        # First attempt raises → structural retry → second attempt raises → re-raised
+        assert agent.run_sync.call_count == 2
+
+    def test_non_structural_error_raises_immediately(self):
+        agent = MagicMock()
+        agent.run_sync.side_effect = AgentRunError("something unexpected")
+        console = MagicMock()
+        deps = MagicMock()
+
+        with (
+            patch(
+                "ossature.build.builder._extract_last_retry_error",
+                return_value="the `old` text was not found in the file",
+            ),
+            pytest.raises(AgentRunError) as exc_info,
+        ):
+            _run_with_retry(agent, "prompt", deps, console, max_retries=3, base_delay=1.0)
+
+        assert agent.run_sync.call_count == 1
+        assert exc_info.value._last_retry_detail == "the `old` text was not found in the file"
+
+    def test_no_detail_raises_without_attribute(self):
+        agent = MagicMock()
+        agent.run_sync.side_effect = AgentRunError("failed")
+        console = MagicMock()
+        deps = MagicMock()
+
+        with (
+            patch(
+                "ossature.build.builder._extract_last_retry_error",
+                return_value=None,
+            ),
+            pytest.raises(AgentRunError) as exc_info,
+        ):
+            _run_with_retry(agent, "prompt", deps, console, max_retries=3, base_delay=1.0)
+
+        assert agent.run_sync.call_count == 1
+        assert not hasattr(exc_info.value, "_last_retry_detail")
+
+
 class TestRunWithRetryJsonDecode:
     @patch("ossature.build.builder.time.sleep")
     def test_retries_on_json_decode_error(self, mock_sleep):

--- a/tests/unit/test_parsers_smd.py
+++ b/tests/unit/test_parsers_smd.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -91,8 +92,6 @@ def _make_valid_with(**overrides: str) -> str:
     """Return MINIMAL_VALID_HEADER with metadata fields overridden."""
     text = MINIMAL_VALID_HEADER
     for key, value in overrides.items():
-        import re
-
         text = re.sub(rf"^@{key}:.*$", f"@{key}: {value}", text, flags=re.MULTILINE)
     return text
 

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -1,0 +1,214 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai.exceptions import AgentRunError
+from pydantic_ai.usage import RunUsage
+
+from ossature.build.builder import TaskResult
+from ossature.shared.llm import LLMRunError, UsageTracker, _fmt_tokens, run_agent_sync
+
+
+class TestFmtTokens:
+    def test_small_number(self):
+        assert _fmt_tokens(0) == "0"
+        assert _fmt_tokens(500) == "500"
+        assert _fmt_tokens(999) == "999"
+
+    def test_thousands(self):
+        assert _fmt_tokens(1_000) == "1.0k"
+        assert _fmt_tokens(1_500) == "1.5k"
+        assert _fmt_tokens(12_345) == "12.3k"
+        assert _fmt_tokens(999_999) == "1000.0k"
+
+    def test_millions(self):
+        assert _fmt_tokens(1_000_000) == "1.0M"
+        assert _fmt_tokens(1_500_000) == "1.5M"
+        assert _fmt_tokens(12_345_678) == "12.3M"
+
+
+class TestUsageTrackerAdd:
+    def test_accumulates_tokens(self):
+        tracker = UsageTracker()
+        usage = RunUsage(input_tokens=100, output_tokens=50, requests=1)
+        tracker.add(usage)
+
+        assert tracker.input_tokens == 100
+        assert tracker.output_tokens == 50
+        assert tracker.requests == 1
+
+    def test_accumulates_multiple_calls(self):
+        tracker = UsageTracker()
+        tracker.add(RunUsage(input_tokens=100, output_tokens=50, requests=1))
+        tracker.add(RunUsage(input_tokens=200, output_tokens=75, requests=1))
+
+        assert tracker.input_tokens == 300
+        assert tracker.output_tokens == 125
+        assert tracker.requests == 2
+
+    def test_accumulates_cache_tokens(self):
+        tracker = UsageTracker()
+        tracker.add(
+            RunUsage(
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=30,
+                cache_write_tokens=20,
+                requests=1,
+            )
+        )
+
+        assert tracker.cache_read_tokens == 30
+        assert tracker.cache_write_tokens == 20
+
+    def test_sets_model_name_from_first_call(self):
+        tracker = UsageTracker()
+        tracker.add(RunUsage(requests=1), model_name="anthropic:claude-sonnet-4-6")
+        tracker.add(RunUsage(requests=1), model_name="openai:gpt-4o")
+
+        assert tracker.model_name == "anthropic:claude-sonnet-4-6"
+
+
+class TestUsageTrackerIadd:
+    def test_combines_two_trackers(self):
+        a = UsageTracker(input_tokens=100, output_tokens=50, requests=1)
+        b = UsageTracker(input_tokens=200, output_tokens=75, requests=2)
+        a += b
+
+        assert a.input_tokens == 300
+        assert a.output_tokens == 125
+        assert a.requests == 3
+
+    def test_preserves_model_name(self):
+        a = UsageTracker(model_name="anthropic:claude-sonnet-4-6")
+        b = UsageTracker(model_name="openai:gpt-4o")
+        a += b
+
+        assert a.model_name == "anthropic:claude-sonnet-4-6"
+
+    def test_inherits_model_name_if_none(self):
+        a = UsageTracker()
+        b = UsageTracker(model_name="openai:gpt-4o")
+        a += b
+
+        assert a.model_name == "openai:gpt-4o"
+
+
+class TestUsageTrackerCost:
+    def test_returns_none_without_model(self):
+        tracker = UsageTracker(input_tokens=1000, output_tokens=500)
+        assert tracker.cost() is None
+
+    def test_returns_none_for_unknown_model(self):
+        tracker = UsageTracker(
+            input_tokens=1000, output_tokens=500, model_name="unknown:fake-model-xyz"
+        )
+        assert tracker.cost() is None
+
+    def test_returns_float_for_known_model(self):
+        tracker = UsageTracker(
+            input_tokens=1000, output_tokens=500, model_name="anthropic:claude-sonnet-4-6"
+        )
+        cost = tracker.cost()
+        assert cost is not None
+        assert isinstance(cost, float)
+        assert cost > 0
+
+    def test_parses_provider_model_format(self):
+        tracker = UsageTracker(input_tokens=1000, output_tokens=500, model_name="openai:gpt-4o")
+        cost = tracker.cost()
+        assert cost is not None
+        assert cost > 0
+
+    def test_works_without_provider_prefix(self):
+        tracker = UsageTracker(input_tokens=1000, output_tokens=500, model_name="gpt-4o")
+        cost = tracker.cost()
+        assert cost is not None
+        assert cost > 0
+
+
+class TestUsageTrackerFormat:
+    def test_format_tokens(self):
+        tracker = UsageTracker(input_tokens=12_345, output_tokens=678)
+        assert tracker.format_tokens() == "12.3k in, 678 out"
+
+    def test_format_cost_known_model(self):
+        tracker = UsageTracker(
+            input_tokens=1000, output_tokens=500, model_name="anthropic:claude-sonnet-4-6"
+        )
+        cost_str = tracker.format_cost()
+        assert cost_str.startswith("$")
+
+    def test_format_cost_unknown_model(self):
+        tracker = UsageTracker(
+            input_tokens=1000, output_tokens=500, model_name="unknown:fake-model"
+        )
+        assert tracker.format_cost() == "?"
+
+    def test_format_cost_small_amount(self):
+        tracker = UsageTracker(
+            input_tokens=10, output_tokens=5, model_name="anthropic:claude-sonnet-4-6"
+        )
+        cost_str = tracker.format_cost()
+        # Small amounts use 4 decimal places
+        assert cost_str.startswith("$0.00")
+
+    def test_format_usage_combines_tokens_and_cost(self):
+        tracker = UsageTracker(
+            input_tokens=1000, output_tokens=500, model_name="unknown:fake-model"
+        )
+        usage_str = tracker.format_usage()
+        assert "1.0k in" in usage_str
+        assert "500 out" in usage_str
+        assert "?" in usage_str
+
+
+class TestRunAgentSyncTracker:
+    def test_populates_tracker_on_success(self):
+        mock_usage = RunUsage(input_tokens=100, output_tokens=50, requests=1)
+        mock_result = MagicMock()
+        mock_result.usage.return_value = mock_usage
+
+        agent = MagicMock()
+        agent.run_sync.return_value = mock_result
+
+        tracker = UsageTracker()
+        run_agent_sync(
+            agent,
+            "prompt",
+            operation="test",
+            model_name="anthropic:claude-sonnet-4-6",
+            tracker=tracker,
+        )
+
+        assert tracker.input_tokens == 100
+        assert tracker.output_tokens == 50
+        assert tracker.requests == 1
+        assert tracker.model_name == "anthropic:claude-sonnet-4-6"
+
+    def test_tracker_not_populated_on_error(self):
+        agent = MagicMock()
+        agent.run_sync.side_effect = AgentRunError("fail")
+
+        tracker = UsageTracker()
+        with pytest.raises(LLMRunError):
+            run_agent_sync(agent, "prompt", operation="test", tracker=tracker)
+
+        assert tracker.input_tokens == 0
+        assert tracker.requests == 0
+
+
+class TestTaskResultSummary:
+    def test_includes_usage_in_summary(self):
+        result = TaskResult(
+            success=True,
+            file_count=2,
+            total_lines=100,
+            elapsed=5.0,
+            usage=UsageTracker(input_tokens=1000, output_tokens=500, model_name="unknown:model"),
+        )
+        summary = result.summary()
+        assert "2 files" in summary
+        assert "100 lines" in summary
+        assert "5.0s" in summary
+        assert "1.0k in" in summary
+        assert "500 out" in summary

--- a/uv.lock
+++ b/uv.lock
@@ -3,19 +3,22 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-03-27T18:47:02.548788Z"
+exclude-newer = "2026-04-01T22:04:38.778382Z"
 exclude-newer-span = "P7D"
+
+[manifest]
+constraints = [{ name = "mistralai", specifier = "<2" }]
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.14"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ee/319d189343e1dc67b1109c950a0d1091fe32498104b5917fbbd806ff58dd/ag_ui_protocol-0.1.14.tar.gz", hash = "sha256:d8e86b308f86a6cf6a5e18ca7154d7642895de2fe94cd2cece57723cdbba6406", size = 5687, upload-time = "2026-03-18T00:43:13.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/99/eaa83816924791fc25ebb44ac7987196b687a3fdf597b1e7a62c69306a8d/ag_ui_protocol-0.1.14-py3-none-any.whl", hash = "sha256:ec072e6a45e0d45b8714e6d54919cc9bde3d097fdc36f7e82953b2f21f1cdbef", size = 8069, upload-time = "2026-03-18T00:43:12.1Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
 ]
 
 [[package]]
@@ -41,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.3"
+version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -52,42 +55,42 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/36/5b6514a9f5d66f4e2597e40dea2e3db271e023eb7a5d22defe96ba560996/aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808", size = 737238, upload-time = "2026-01-03T17:31:17.909Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/49/459327f0d5bcd8c6c9ca69e60fdeebc3622861e696490d8674a6d0cb90a6/aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415", size = 492292, upload-time = "2026-01-03T17:31:19.919Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f", size = 493021, upload-time = "2026-01-03T17:31:21.636Z" },
-    { url = "https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6", size = 1717263, upload-time = "2026-01-03T17:31:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/71/f2/7bddc7fd612367d1459c5bcf598a9e8f7092d6580d98de0e057eb42697ad/aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687", size = 1669107, upload-time = "2026-01-03T17:31:25.334Z" },
-    { url = "https://files.pythonhosted.org/packages/00/5a/1aeaecca40e22560f97610a329e0e5efef5e0b5afdf9f857f0d93839ab2e/aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26", size = 1760196, upload-time = "2026-01-03T17:31:27.394Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f8/0ff6992bea7bd560fc510ea1c815f87eedd745fe035589c71ce05612a19a/aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a", size = 1843591, upload-time = "2026-01-03T17:31:29.238Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1", size = 1720277, upload-time = "2026-01-03T17:31:31.053Z" },
-    { url = "https://files.pythonhosted.org/packages/84/45/23f4c451d8192f553d38d838831ebbc156907ea6e05557f39563101b7717/aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25", size = 1548575, upload-time = "2026-01-03T17:31:32.87Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/ed/0a42b127a43712eda7807e7892c083eadfaf8429ca8fb619662a530a3aab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603", size = 1679455, upload-time = "2026-01-03T17:31:34.76Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b5/c05f0c2b4b4fe2c9d55e73b6d3ed4fd6c9dc2684b1d81cbdf77e7fad9adb/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a", size = 1687417, upload-time = "2026-01-03T17:31:36.699Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6b/915bc5dad66aef602b9e459b5a973529304d4e89ca86999d9d75d80cbd0b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926", size = 1729968, upload-time = "2026-01-03T17:31:38.622Z" },
-    { url = "https://files.pythonhosted.org/packages/11/3b/e84581290a9520024a08640b63d07673057aec5ca548177a82026187ba73/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba", size = 1545690, upload-time = "2026-01-03T17:31:40.57Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/04/0c3655a566c43fd647c81b895dfe361b9f9ad6d58c19309d45cff52d6c3b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c", size = 1746390, upload-time = "2026-01-03T17:31:42.857Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/71165b26978f719c3419381514c9690bd5980e764a09440a10bb816ea4ab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43", size = 1702188, upload-time = "2026-01-03T17:31:44.984Z" },
-    { url = "https://files.pythonhosted.org/packages/29/a7/cbe6c9e8e136314fa1980da388a59d2f35f35395948a08b6747baebb6aa6/aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1", size = 433126, upload-time = "2026-01-03T17:31:47.463Z" },
-    { url = "https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984", size = 459128, upload-time = "2026-01-03T17:31:49.2Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/2a/3c79b638a9c3d4658d345339d22070241ea341ed4e07b5ac60fb0f418003/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c", size = 769512, upload-time = "2026-01-03T17:31:51.134Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b9/3e5014d46c0ab0db8707e0ac2711ed28c4da0218c358a4e7c17bae0d8722/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592", size = 506444, upload-time = "2026-01-03T17:31:52.85Z" },
-    { url = "https://files.pythonhosted.org/packages/90/03/c1d4ef9a054e151cd7839cdc497f2638f00b93cbe8043983986630d7a80c/aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f", size = 510798, upload-time = "2026-01-03T17:31:54.91Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/76/8c1e5abbfe8e127c893fe7ead569148a4d5a799f7cf958d8c09f3eedf097/aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29", size = 1868835, upload-time = "2026-01-03T17:31:56.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ac/984c5a6f74c363b01ff97adc96a3976d9c98940b8969a1881575b279ac5d/aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc", size = 1720486, upload-time = "2026-01-03T17:31:58.65Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/9a/b7039c5f099c4eb632138728828b33428585031a1e658d693d41d07d89d1/aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2", size = 1847951, upload-time = "2026-01-03T17:32:00.989Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/02/3bec2b9a1ba3c19ff89a43a19324202b8eb187ca1e928d8bdac9bbdddebd/aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587", size = 1941001, upload-time = "2026-01-03T17:32:03.122Z" },
-    { url = "https://files.pythonhosted.org/packages/37/df/d879401cedeef27ac4717f6426c8c36c3091c6e9f08a9178cc87549c537f/aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8", size = 1797246, upload-time = "2026-01-03T17:32:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/15/be122de1f67e6953add23335c8ece6d314ab67c8bebb3f181063010795a7/aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632", size = 1627131, upload-time = "2026-01-03T17:32:07.607Z" },
-    { url = "https://files.pythonhosted.org/packages/12/12/70eedcac9134cfa3219ab7af31ea56bc877395b1ac30d65b1bc4b27d0438/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64", size = 1795196, upload-time = "2026-01-03T17:32:09.59Z" },
-    { url = "https://files.pythonhosted.org/packages/32/11/b30e1b1cd1f3054af86ebe60df96989c6a414dd87e27ad16950eee420bea/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0", size = 1782841, upload-time = "2026-01-03T17:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/88/0d/d98a9367b38912384a17e287850f5695c528cff0f14f791ce8ee2e4f7796/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56", size = 1795193, upload-time = "2026-01-03T17:32:13.705Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a5/a2dfd1f5ff5581632c7f6a30e1744deda03808974f94f6534241ef60c751/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72", size = 1621979, upload-time = "2026-01-03T17:32:15.965Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/12973c382ae7c1cccbc4417e129c5bf54c374dfb85af70893646e1f0e749/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df", size = 1822193, upload-time = "2026-01-03T17:32:18.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/5f/24155e30ba7f8c96918af1350eb0663e2430aad9e001c0489d89cd708ab1/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa", size = 1769801, upload-time = "2026-01-03T17:32:20.25Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/f8/7314031ff5c10e6ece114da79b338ec17eeff3a079e53151f7e9f43c4723/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767", size = 466523, upload-time = "2026-01-03T17:32:22.215Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/278a98c715ae467624eafe375542d8ba9b4383a016df8fdefe0ae28382a7/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344", size = 499694, upload-time = "2026-01-03T17:32:24.546Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
 ]
 
 [[package]]
@@ -122,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -134,9 +137,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/68/565f13059c0a6a6fd5f96f306f2a0fb478a0e1174ec18a4df16b5fac9379/anthropic-0.88.0.tar.gz", hash = "sha256:f4c7f6863d08c869913516f08d658fe53caaf8bcc4fbea3218df343d2a876c58", size = 596654, upload-time = "2026-04-01T19:59:05.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ac/68f646998160c9f2e6f9353a31dd87292ef02b915b455aaf70a52a059a75/anthropic-0.88.0-py3-none-any.whl", hash = "sha256:71898b32332bc75d9739bc10095288d40a29605da6d00da2fe832b1aa036552f", size = 478338, upload-time = "2026-04-01T19:59:03.832Z" },
 ]
 
 [[package]]
@@ -215,30 +218,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.77"
+version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/f6/b280afd91b2284744c0bb26afa1272bd60270726b4d3999fc27b68200854/boto3-1.42.77.tar.gz", hash = "sha256:c6d9b05e5b86767d4c6ef762f155c891366e5951162f71d030e109fe531f4fd9", size = 112773, upload-time = "2026-03-26T19:25:35.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/4d/40029c26b535c41333a0b11573127cfc548fdcb1cbcd1798ea7046c56bab/boto3-1.42.81.tar.gz", hash = "sha256:e5c0d57229763007151be6d388319514a040ccdc922fbb27e37c3100a7fbc01a", size = 112785, upload-time = "2026-04-01T19:35:34.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/e6/e27fb0956bd52e6ac222d47eaa04d267887ca1d52a6b3c25d2006c8dc9e6/boto3-1.42.77-py3-none-any.whl", hash = "sha256:95eb3ef693068586f70ca3f29c43701c34a9a73d0df413ea7eaff138efa4a6b9", size = 140555, upload-time = "2026-03-26T19:25:32.069Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e5/a1a8e8bbaaa258645fe04bb6a39d7d57b6a12650312f880b8e9add638a56/boto3-1.42.81-py3-none-any.whl", hash = "sha256:216f43e308f1f65e69f57784e5042ffcb2eb6a45e370d118ea384510c148fde7", size = 140554, upload-time = "2026-04-01T19:35:32.71Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.77"
+version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/97/1800633988e890b4eea0706b2671342eddfeb33c1eb1d2fe28a8117f7907/botocore-1.42.77.tar.gz", hash = "sha256:cbb0ac410fab4aa0839a521329f970b271ec298d67465ed7fa7d095c0dad9f48", size = 15023911, upload-time = "2026-03-26T19:25:21.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/5f/b0bb9a8768398fb131e1fe722c9cc5b18f74d21ca1970efe8576912b2c6e/botocore-1.42.81.tar.gz", hash = "sha256:48e6f6f52de1cc107a34810309b8ca998ea9bb719a3fe4c06f903a604b3138cb", size = 15129980, upload-time = "2026-04-01T19:35:23.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/7c/6280e6b61f8c232eebd72cae950ed52ce2f38fecf2d178713de3cb1f6298/botocore-1.42.77-py3-none-any.whl", hash = "sha256:807bc2c3825bec6f025506ceeba5f7f111a00de8d58f35c679ee16c8ff6e7b10", size = 14699672, upload-time = "2026-03-26T19:25:15.996Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/c7a01649a6cb7219b233d2ed071ab925e52cdb64e15ce935024c0007376f/botocore-1.42.81-py3-none-any.whl", hash = "sha256:bcef8c93c20ebeba95e4f8b9edfbffbc78a0e11235425a92ee32e48fd8e03c37", size = 14807198, upload-time = "2026-04-01T19:35:20.437Z" },
 ]
 
 [[package]]
@@ -598,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -623,9 +626,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -680,11 +683,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -732,7 +735,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.68.0"
+version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -746,9 +749,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/f059982dbcb658cc535c81bbcbe7e2c040d675f4b563b03cdb01018a4bc3/google_genai-1.68.0.tar.gz", hash = "sha256:ac30c0b8bc630f9372993a97e4a11dae0e36f2e10d7c55eacdca95a9fa14ca96", size = 511285, upload-time = "2026-03-18T01:03:18.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/dd/28e4682904b183acbfad3fe6409f13a42f69bb8eab6e882d3bcbea1dde01/google_genai-1.70.0.tar.gz", hash = "sha256:36b67b0fc6f319e08d1f1efd808b790107b1809c8743a05d55dfcf9d9fad7719", size = 519550, upload-time = "2026-04-01T10:52:46.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/de/7d3ee9c94b74c3578ea4f88d45e8de9405902f857932334d81e89bce3dfa/google_genai-1.68.0-py3-none-any.whl", hash = "sha256:a1bc9919c0e2ea2907d1e319b65471d3d6d58c54822039a249fe1323e4178d15", size = 750912, upload-time = "2026-03-18T01:03:15.983Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/d4564c8a9beaf6a3cef8d70fa6354318572cebfee65db4f01af0d41f45ba/google_genai-1.70.0-py3-none-any.whl", hash = "sha256:b74c24549d8b4208f4c736fd11857374788e1ffffc725de45d706e35c97fceee", size = 760584, upload-time = "2026-04-01T10:52:44.349Z" },
 ]
 
 [[package]]
@@ -791,23 +794,23 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.78.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
-    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
-    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
-    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
-    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -821,26 +824,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.2"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/0f/fcd2504015eab26358d8f0f232a1aed6b8d363a011adef83fe130bff88f7/hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7", size = 3796493, upload-time = "2026-03-13T06:58:39.267Z" },
-    { url = "https://files.pythonhosted.org/packages/82/56/19c25105ff81731ca6d55a188b5de2aa99d7a2644c7aa9de1810d5d3b726/hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418", size = 3555797, upload-time = "2026-03-13T06:58:37.546Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/8933c073186849b5e06762aa89847991d913d10a95d1603eb7f2c3834086/hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146", size = 4212127, upload-time = "2026-03-13T06:58:30.539Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/01/f89ebba4e369b4ed699dcb60d3152753870996f41c6d22d3d7cac01310e1/hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0", size = 3987788, upload-time = "2026-03-13T06:58:29.139Z" },
-    { url = "https://files.pythonhosted.org/packages/84/4d/8a53e5ffbc2cc33bbf755382ac1552c6d9af13f623ed125fe67cc3e6772f/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d", size = 4188315, upload-time = "2026-03-13T06:58:48.017Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b8/b7a1c1b5592254bd67050632ebbc1b42cc48588bf4757cb03c2ef87e704a/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570", size = 4428306, upload-time = "2026-03-13T06:58:49.502Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0c/40779e45b20e11c7c5821a94135e0207080d6b3d76e7b78ccb413c6f839b/hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6", size = 3665826, upload-time = "2026-03-13T06:58:59.88Z" },
-    { url = "https://files.pythonhosted.org/packages/51/4c/e2688c8ad1760d7c30f7c429c79f35f825932581bc7c9ec811436d2f21a0/hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8", size = 3529113, upload-time = "2026-03-13T06:58:58.491Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
-    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
-    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
-    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -928,6 +931,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "invoke"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
 ]
 
 [[package]]
@@ -1024,15 +1036,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
-]
-
-[[package]]
-name = "jsonpath-python"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/db/2f4ecc24da35c6142b39c353d5b7c16eef955cc94b35a48d3fa47996d7c3/jsonpath_python-1.1.5.tar.gz", hash = "sha256:ceea2efd9e56add09330a2c9631ea3d55297b9619348c1055e5bfb9cb0b8c538", size = 87352, upload-time = "2026-03-17T06:16:40.597Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/50/1a313fb700526b134c71eb8a225d8b83be0385dbb0204337b4379c698cef/jsonpath_python-1.1.5-py3-none-any.whl", hash = "sha256:a60315404d70a65e76c9a782c84e50600480221d94a58af47b7b4d437351cb4b", size = 14090, upload-time = "2026-03-17T06:16:39.152Z" },
 ]
 
 [[package]]
@@ -1138,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.30.0"
+version = "4.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -1149,9 +1152,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/77/ed3b6453c0c8027724ceb968ca17e550c47e58cdb5dc27458392db40e327/logfire-4.30.0.tar.gz", hash = "sha256:460ed1a7433d88570659903f31b6f9b70903110addbb18b1cf7b414cdb516bb5", size = 1058676, upload-time = "2026-03-23T17:08:28.944Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/fc/21f923243d8c3ca2ebfa97de46970ced734e66ac634c1c35b6abb41300f1/logfire-4.31.0.tar.gz", hash = "sha256:361bfda17c9d70ada5d220211033bae06b871ddac9d5b06978bc0ceca6b8e658", size = 1080609, upload-time = "2026-03-27T19:00:46.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/3a/ead5b87ff38292e0ef800b1d184a9a4eedf9f7ce1cf86264b4798a0a8b14/logfire-4.30.0-py3-none-any.whl", hash = "sha256:a520a2b6da7765bc15143fd4098c6f9ec56a836bf3a046f06c823c73af932f3a", size = 302618, upload-time = "2026-03-23T17:08:25.923Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1a/8c860e35bf847ac0d647d94bad89dccbb66cbcafdd61d8334f8cc7cfdd58/logfire-4.31.0-py3-none-any.whl", hash = "sha256:49fad38b5e6f199a98e9c8814e860c8a42595bb81479b52a20413e53ee475b72", size = 308896, upload-time = "2026-03-27T19:00:43.107Z" },
 ]
 
 [package.optional-dependencies]
@@ -1161,11 +1164,11 @@ httpx = [
 
 [[package]]
 name = "logfire-api"
-version = "4.30.0"
+version = "4.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/19/1400a6b1c79c05ccf8058e09f1b10201edce9b6f4ce3094c3200496f6e27/logfire_api-4.30.0.tar.gz", hash = "sha256:ab24c4283fbe90b0f275e59f69ce3b86712cbabec6aa7ae64f411e754c66e3fc", size = 76349, upload-time = "2026-03-23T17:08:30.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/8d5a3c1c282d5f2bd9f5e9ddd5288d1414a53301ce389af9016b6d82bd50/logfire_api-4.31.0.tar.gz", hash = "sha256:fc4b01257ebd4ce297ad374ed201eb1a9213b999f6ae6df45cfca5bd0ef378f8", size = 77838, upload-time = "2026-03-27T19:00:47.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/ca/7833b883059b85aef22a2a485e4a7a358c3dda02e1823f87913c411e6410/logfire_api-4.30.0-py3-none-any.whl", hash = "sha256:9138976dc30df4cf21617f1b188a84781683ef2ba88c46008774a7081f16f2c9", size = 121411, upload-time = "2026-03-23T17:08:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/26/27/9372b7492b3e146908d520f8599909311cd930175801ad219171fafc6f3e/logfire_api-4.31.0-py3-none-any.whl", hash = "sha256:3c1f502fd4eb8ef0996427a5cf275fd8f327f38600650a1f53071a8171c812db", size = 123402, upload-time = "2026-03-27T19:00:44.952Z" },
 ]
 
 [[package]]
@@ -1264,21 +1267,23 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.1.3"
+version = "1.12.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
     { name = "httpx" },
-    { name = "jsonpath-python" },
+    { name = "invoke" },
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "python-dateutil" },
+    { name = "pyyaml" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/98/5fe39d514c19477f06a07e088ce4a44c2e60ac9deebefb9e2c8ed8ef87d2/mistralai-2.1.3.tar.gz", hash = "sha256:0c5de4855b043cd0582406d5c1ddfd91e176f484a158e6ee0b4a0054231be266", size = 331929, upload-time = "2026-03-23T15:00:29.579Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/12/c3476c53e907255b5f485f085ba50dd9a84b40fe662e9a888d6ded26fa7b/mistralai-1.12.4.tar.gz", hash = "sha256:e52b53bab58025dcd208eeac13e3c3df5778d4112eeca1f08124096c7738929f", size = 243129, upload-time = "2026-02-20T17:55:13.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/7c/f91a26bf469c1cff57325379afa112baeb113ac577d28e69dd408cee5745/mistralai-2.1.3-py3-none-any.whl", hash = "sha256:26daac3bdc69fc2dd58f2c421710eb34131be7883b44a9ea81904a6306e6a90a", size = 754931, upload-time = "2026-03-23T15:00:30.934Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/98d825105c450b9c67c27026caa374112b7e466c18331601d02ca278a01b/mistralai-1.12.4-py3-none-any.whl", hash = "sha256:7b69fcbc306436491ad3377fbdead527c9f3a0ce145ec029bf04c6308ff2cca6", size = 509321, upload-time = "2026-02-20T17:55:15.27Z" },
 ]
 
 [[package]]
@@ -1406,7 +1411,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.19.1"
+version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -1414,15 +1419,23 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
+    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
+    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
 ]
 
 [[package]]
@@ -1606,6 +1619,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "content-types" },
+    { name = "genai-prices" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "questionary" },
@@ -1628,6 +1642,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "content-types", specifier = ">=0.3.0" },
+    { name = "genai-prices", specifier = ">=0.0.51" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-ai", specifier = ">=1.62.0" },
     { name = "questionary", specifier = ">=2.1.1" },
@@ -1843,19 +1858,19 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.73.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "spec", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/f6/4fe7d179cbf55d0933bc3afaab14adb702cc7ff1bf876bac2a432eaf1dcb/pydantic_ai-1.73.0.tar.gz", hash = "sha256:11158b40a85b13a2f075680a9812929c9768c10771bcc27db1bfcceda59139e6", size = 12658, upload-time = "2026-03-27T03:49:47.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/96/aaaadefd68960fc5bde4f3cef6555ee0a33156599c8d08b123b5571d8b2e/pydantic_ai-1.75.0.tar.gz", hash = "sha256:06cbe1843a3a584ba071e7ed9219a2637ab158a6d6c4df5e4163d0a396358c0e", size = 12659, upload-time = "2026-04-01T00:38:20.831Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/5d/34811942086587fc66ab62c10df2b029d994ef9c5578f23fc5403f143322/pydantic_ai-1.73.0-py3-none-any.whl", hash = "sha256:ec06153541fcb0ef5a69d314255284d22b395d9c71ce6b258c1987f9e255b6bc", size = 7551, upload-time = "2026-03-27T03:49:39.585Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c9/713a9ac62072c1c63ce624cd3d017d292d3300dc888ab08335915422036f/pydantic_ai-1.75.0-py3-none-any.whl", hash = "sha256:9e267c7e86b5f77f9e9e2cd3b3d658f89905e504716da55f91fe4cbea1cb1a17", size = 7551, upload-time = "2026-04-01T00:38:11.78Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.73.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -1866,9 +1881,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/1b/a5e18c7c721a3cfce5b17f86cb99e4142fcb70f38ea6d2b8963c2df445e1/pydantic_ai_slim-1.73.0.tar.gz", hash = "sha256:758d5bedb4b4f484c433672639bfc87af216a38453b1539ae10928a9ca62ff62", size = 497208, upload-time = "2026-03-27T03:49:49.459Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/38/79478740dad656fcf8d293ef2d43dfbb7b6b8edec7cc5ce36fbbf26bc28f/pydantic_ai_slim-1.75.0.tar.gz", hash = "sha256:5132e7fc135e062cde13ecd389940bccd84feadabd4ed810f61a099068d271a7", size = 504543, upload-time = "2026-04-01T00:38:23.263Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/3b/6aa1874cd0ccbc83c17c8eb308834bf004c8d4344c27cd8048851d4b284d/pydantic_ai_slim-1.73.0-py3-none-any.whl", hash = "sha256:f7176ce6c78539e1070d7e22549186862c2f6e6ea8b05b3aaad8a1942ba1ff4f", size = 638701, upload-time = "2026-03-27T03:49:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d8/15b05d411e1a08d894f0a0f6c56632930f6852cee282ef92e4dde9533021/pydantic_ai_slim-1.75.0-py3-none-any.whl", hash = "sha256:8ba5ad332be6c2f8c62e0778504086a2d9441cc28064bb335a3caf6d270b463f", size = 646340, upload-time = "2026-04-01T00:38:14.842Z" },
 ]
 
 [package.optional-dependencies]
@@ -1982,7 +1997,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.73.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1992,14 +2007,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/45/ce1f9b97c4838f940c98693bc1d6298f0e1396355998942b095ce17157fe/pydantic_evals-1.73.0.tar.gz", hash = "sha256:c1f38ad9c4f566bee6958c92f205b8200957b4baf3dd5239e2a4a06edd28e3dc", size = 56137, upload-time = "2026-03-27T03:49:50.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/dd/109412f597d278ac2ac19c9bae27ce2916b2db8382539849b92e32231220/pydantic_evals-1.75.0.tar.gz", hash = "sha256:789ef1a52af6bf5b7a2ad48490f04925f59ebccb5844ae795b94d190a6f5927e", size = 65846, upload-time = "2026-04-01T00:38:24.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/4e/aefc34a68adc165ddec22c0632cb3076579c46751ac11acdf8cec6462891/pydantic_evals-1.73.0-py3-none-any.whl", hash = "sha256:0609210d4825cc8339b5cb649be38321450b46d6e87d72c1ffde73598741fd5a", size = 67143, upload-time = "2026-03-27T03:49:44.298Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cc/a92b5da973567eda70a61d035ebb7a69de613945078b03dc57f7823de667/pydantic_evals-1.75.0-py3-none-any.whl", hash = "sha256:65c06b7e7ded266d7e754cd03782e76002f80639c079f9d1b834a7c7117de8b4", size = 77739, upload-time = "2026-04-01T00:38:16.77Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.73.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2007,9 +2022,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/22/d479ea32e3c712c6711e41157fb975d81582e5171510e4c662f21a85e9fe/pydantic_graph-1.73.0.tar.gz", hash = "sha256:f0d3e4984af1d902cdda1ccd3fcd86949d45d3ed21559e781f7cf9eace2ed914", size = 58717, upload-time = "2026-03-27T03:49:51.967Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/4c/7d6e07ad9affc781201a8ca0a59e655952403f0e14416b2563d4483c1a4c/pydantic_graph-1.75.0.tar.gz", hash = "sha256:c46feb2a0d0e87a4487324ea91e5e547114996bd4026542eebddcaee3e4989bd", size = 58713, upload-time = "2026-04-01T00:38:25.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/b3/4cc0b1c543b8a0c1f9add7bdeb2e8cd583961a795664a1a74d1fc8200416/pydantic_graph-1.73.0-py3-none-any.whl", hash = "sha256:aaab8b1580885f5108401db0a7da58d6c7643e467eb626b8a1364b1030327de0", size = 72504, upload-time = "2026-03-27T03:49:45.668Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/29992d327932faaa511de8fbcf58f75171a70de0986d3aed21fe93888be8/pydantic_graph-1.75.0-py3-none-any.whl", hash = "sha256:ea290452de13477699fe60745fe70f01ae3d16c5e50457e0b3d65a1ea1c9c703", size = 72502, upload-time = "2026-04-01T00:38:18.118Z" },
 ]
 
 [[package]]
@@ -2040,11 +2055,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -2063,15 +2078,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -2227,47 +2242,47 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.2.28"
+version = "2026.3.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184, upload-time = "2026-02-28T02:19:42.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/93/5ab3e899c47fa7994e524447135a71cd121685a35c8fe35029005f8b236f/regex-2026.3.32.tar.gz", hash = "sha256:f1574566457161678297a116fa5d1556c5a4159d64c5ff7c760e7c564bf66f16", size = 415605, upload-time = "2026-03-28T21:49:22.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/03/691015f7a7cb1ed6dacb2ea5de5682e4858e05a4c5506b2839cd533bbcd6/regex-2026.2.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:78454178c7df31372ea737996fb7f36b3c2c92cccc641d251e072478afb4babc", size = 489497, upload-time = "2026-02-28T02:18:30.889Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ba/8db8fd19afcbfa0e1036eaa70c05f20ca8405817d4ad7a38a6b4c2f031ac/regex-2026.2.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:5d10303dd18cedfd4d095543998404df656088240bcfd3cd20a8f95b861f74bd", size = 291295, upload-time = "2026-02-28T02:18:33.426Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/79/9aa0caf089e8defef9b857b52fc53801f62ff868e19e5c83d4a96612eba1/regex-2026.2.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19a9c9e0a8f24f39d575a6a854d516b48ffe4cbdcb9de55cb0570a032556ecff", size = 289275, upload-time = "2026-02-28T02:18:35.247Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/26/ee53117066a30ef9c883bf1127eece08308ccf8ccd45c45a966e7a665385/regex-2026.2.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09500be324f49b470d907b3ef8af9afe857f5cca486f853853f7945ddbf75911", size = 797176, upload-time = "2026-02-28T02:18:37.15Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1b/67fb0495a97259925f343ae78b5d24d4a6624356ae138b57f18bd43006e4/regex-2026.2.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb1c4ff62277d87a7335f2c1ea4e0387b8f2b3ad88a64efd9943906aafad4f33", size = 863813, upload-time = "2026-02-28T02:18:39.478Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/93ac9bbafc53618091c685c7ed40239a90bf9f2a82c983f0baa97cb7ae07/regex-2026.2.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b8b3f1be1738feadc69f62daa250c933e85c6f34fa378f54a7ff43807c1b9117", size = 908678, upload-time = "2026-02-28T02:18:41.619Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7a/a8f5e0561702b25239846a16349feece59712ae20598ebb205580332a471/regex-2026.2.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc8ed8c3f41c27acb83f7b6a9eb727a73fc6663441890c5cb3426a5f6a91ce7d", size = 801528, upload-time = "2026-02-28T02:18:43.624Z" },
-    { url = "https://files.pythonhosted.org/packages/96/5d/ed6d4cbde80309854b1b9f42d9062fee38ade15f7eb4909f6ef2440403b5/regex-2026.2.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa539be029844c0ce1114762d2952ab6cfdd7c7c9bd72e0db26b94c3c36dcc5a", size = 775373, upload-time = "2026-02-28T02:18:46.102Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/e9/6e53c34e8068b9deec3e87210086ecb5b9efebdefca6b0d3fa43d66dcecb/regex-2026.2.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7900157786428a79615a8264dac1f12c9b02957c473c8110c6b1f972dcecaddf", size = 784859, upload-time = "2026-02-28T02:18:48.269Z" },
-    { url = "https://files.pythonhosted.org/packages/48/3c/736e1c7ca7f0dcd2ae33819888fdc69058a349b7e5e84bc3e2f296bbf794/regex-2026.2.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0b1d2b07614d95fa2bf8a63fd1e98bd8fa2b4848dc91b1efbc8ba219fdd73952", size = 857813, upload-time = "2026-02-28T02:18:50.576Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/7c/48c4659ad9da61f58e79dbe8c05223e0006696b603c16eb6b5cbfbb52c27/regex-2026.2.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b389c61aa28a79c2e0527ac36da579869c2e235a5b208a12c5b5318cda2501d8", size = 763705, upload-time = "2026-02-28T02:18:52.59Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/a1/bc1c261789283128165f71b71b4b221dd1b79c77023752a6074c102f18d8/regex-2026.2.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f467cb602f03fbd1ab1908f68b53c649ce393fde056628dc8c7e634dab6bfc07", size = 848734, upload-time = "2026-02-28T02:18:54.595Z" },
-    { url = "https://files.pythonhosted.org/packages/10/d8/979407faf1397036e25a5ae778157366a911c0f382c62501009f4957cf86/regex-2026.2.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c8cb2deba42f5ec1ede46374e990f8adc5e6456a57ac1a261b19be6f28e4e6", size = 789871, upload-time = "2026-02-28T02:18:57.34Z" },
-    { url = "https://files.pythonhosted.org/packages/03/23/da716821277115fcb1f4e3de1e5dc5023a1e6533598c486abf5448612579/regex-2026.2.28-cp314-cp314-win32.whl", hash = "sha256:9036b400b20e4858d56d117108d7813ed07bb7803e3eed766675862131135ca6", size = 271825, upload-time = "2026-02-28T02:18:59.202Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ff/90696f535d978d5f16a52a419be2770a8d8a0e7e0cfecdbfc31313df7fab/regex-2026.2.28-cp314-cp314-win_amd64.whl", hash = "sha256:1d367257cd86c1cbb97ea94e77b373a0bbc2224976e247f173d19e8f18b4afa7", size = 280548, upload-time = "2026-02-28T02:19:01.049Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f9/5e1b5652fc0af3fcdf7677e7df3ad2a0d47d669b34ac29a63bb177bb731b/regex-2026.2.28-cp314-cp314-win_arm64.whl", hash = "sha256:5e68192bb3a1d6fb2836da24aa494e413ea65853a21505e142e5b1064a595f3d", size = 273444, upload-time = "2026-02-28T02:19:03.255Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/eb/8389f9e940ac89bcf58d185e230a677b4fd07c5f9b917603ad5c0f8fa8fe/regex-2026.2.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a5dac14d0872eeb35260a8e30bac07ddf22adc1e3a0635b52b02e180d17c9c7e", size = 492546, upload-time = "2026-02-28T02:19:05.378Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c7/09441d27ce2a6fa6a61ea3150ea4639c1dcda9b31b2ea07b80d6937b24dd/regex-2026.2.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec0c608b7a7465ffadb344ed7c987ff2f11ee03f6a130b569aa74d8a70e8333c", size = 292986, upload-time = "2026-02-28T02:19:07.24Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/69/4144b60ed7760a6bd235e4087041f487aa4aa62b45618ce018b0c14833ea/regex-2026.2.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7815afb0ca45456613fdaf60ea9c993715511c8d53a83bc468305cbc0ee23c7", size = 291518, upload-time = "2026-02-28T02:19:09.698Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/be/77e5426cf5948c82f98c53582009ca9e94938c71f73a8918474f2e2990bb/regex-2026.2.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b059e71ec363968671693a78c5053bd9cb2fe410f9b8e4657e88377ebd603a2e", size = 809464, upload-time = "2026-02-28T02:19:12.494Z" },
-    { url = "https://files.pythonhosted.org/packages/45/99/2c8c5ac90dc7d05c6e7d8e72c6a3599dc08cd577ac476898e91ca787d7f1/regex-2026.2.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8cf76f1a29f0e99dcfd7aef1551a9827588aae5a737fe31442021165f1920dc", size = 869553, upload-time = "2026-02-28T02:19:15.151Z" },
-    { url = "https://files.pythonhosted.org/packages/53/34/daa66a342f0271e7737003abf6c3097aa0498d58c668dbd88362ef94eb5d/regex-2026.2.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:180e08a435a0319e6a4821c3468da18dc7001987e1c17ae1335488dfe7518dd8", size = 915289, upload-time = "2026-02-28T02:19:17.331Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c7/e22c2aaf0a12e7e22ab19b004bb78d32ca1ecc7ef245949935463c5567de/regex-2026.2.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e496956106fd59ba6322a8ea17141a27c5040e5ee8f9433ae92d4e5204462a0", size = 812156, upload-time = "2026-02-28T02:19:20.011Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/bb/2dc18c1efd9051cf389cd0d7a3a4d90f6804b9fff3a51b5dc3c85b935f71/regex-2026.2.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bba2b18d70eeb7b79950f12f633beeecd923f7c9ad6f6bae28e59b4cb3ab046b", size = 782215, upload-time = "2026-02-28T02:19:22.047Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1e/9e4ec9b9013931faa32226ec4aa3c71fe664a6d8a2b91ac56442128b332f/regex-2026.2.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6db7bfae0f8a2793ff1f7021468ea55e2699d0790eb58ee6ab36ae43aa00bc5b", size = 798925, upload-time = "2026-02-28T02:19:24.173Z" },
-    { url = "https://files.pythonhosted.org/packages/71/57/a505927e449a9ccb41e2cc8d735e2abe3444b0213d1cf9cb364a8c1f2524/regex-2026.2.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d0b02e8b7e5874b48ae0f077ecca61c1a6a9f9895e9c6dfb191b55b242862033", size = 864701, upload-time = "2026-02-28T02:19:26.376Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/ad/c62cb60cdd93e13eac5b3d9d6bd5d284225ed0e3329426f94d2552dd7cca/regex-2026.2.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:25b6eb660c5cf4b8c3407a1ed462abba26a926cc9965e164268a3267bcc06a43", size = 770899, upload-time = "2026-02-28T02:19:29.38Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/5a/874f861f5c3d5ab99633e8030dee1bc113db8e0be299d1f4b07f5b5ec349/regex-2026.2.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:5a932ea8ad5d0430351ff9c76c8db34db0d9f53c1d78f06022a21f4e290c5c18", size = 854727, upload-time = "2026-02-28T02:19:31.494Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ca/d2c03b0efde47e13db895b975b2be6a73ed90b8ba963677927283d43bf74/regex-2026.2.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1c2c95e1a2b0f89d01e821ff4de1be4b5d73d1f4b0bf679fa27c1ad8d2327f1a", size = 800366, upload-time = "2026-02-28T02:19:34.248Z" },
-    { url = "https://files.pythonhosted.org/packages/14/bd/ee13b20b763b8989f7c75d592bfd5de37dc1181814a2a2747fedcf97e3ba/regex-2026.2.28-cp314-cp314t-win32.whl", hash = "sha256:bbb882061f742eb5d46f2f1bd5304055be0a66b783576de3d7eef1bed4778a6e", size = 274936, upload-time = "2026-02-28T02:19:36.313Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e7/d8020e39414c93af7f0d8688eabcecece44abfd5ce314b21dfda0eebd3d8/regex-2026.2.28-cp314-cp314t-win_amd64.whl", hash = "sha256:6591f281cb44dc13de9585b552cec6fc6cf47fb2fe7a48892295ee9bc4a612f9", size = 284779, upload-time = "2026-02-28T02:19:38.625Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c0/ad225f4a405827486f1955283407cf758b6d2fb966712644c5f5aef33d1b/regex-2026.2.28-cp314-cp314t-win_arm64.whl", hash = "sha256:dee50f1be42222f89767b64b283283ef963189da0dda4a515aa54a5563c62dec", size = 275010, upload-time = "2026-02-28T02:19:40.65Z" },
+    { url = "https://files.pythonhosted.org/packages/32/68/ff024bf6131b7446a791a636dbbb7fa732d586f33b276d84b3460ea49393/regex-2026.3.32-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a416ee898ecbc5d8b283223b4cf4d560f93244f6f7615c1bd67359744b00c166", size = 490430, upload-time = "2026-03-28T21:48:05.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/039d9164817ee298f2a2d0246001afe662241dcbec0eedd1fe03e2a2555e/regex-2026.3.32-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d76d62909bfb14521c3f7cfd5b94c0c75ec94b0a11f647d2f604998962ec7b6c", size = 291948, upload-time = "2026-03-28T21:48:07.666Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/77f684d90ffe3e99b828d3cabb87a0f1601d2b9decd1333ff345809b1d02/regex-2026.3.32-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:631f7d95c83f42bccfe18946a38ad27ff6b6717fb4807e60cf24860b5eb277fc", size = 289786, upload-time = "2026-03-28T21:48:09.562Z" },
+    { url = "https://files.pythonhosted.org/packages/83/70/bd76069a0304e924682b2efd8683a01617a7e1da9b651af73039d8da76a4/regex-2026.3.32-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12917c6c6813ffcdfb11680a04e4d63c5532b88cf089f844721c5f41f41a63ad", size = 796672, upload-time = "2026-03-28T21:48:11.568Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/c2d7d9a5671e111a2c16d57e0cb03e1ce35b28a115901590528aa928bb5b/regex-2026.3.32-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e221b615f83b15887636fcb90ed21f1a19541366f8b7ba14ba1ad8304f4ded4", size = 866556, upload-time = "2026-03-28T21:48:14.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b9/9921a31931d0bc3416ac30205471e0e2ed60dcbd16fc922bbd69b427322b/regex-2026.3.32-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4f9ae4755fa90f1dc2d0d393d572ebc134c0fe30fcfc0ab7e67c1db15f192041", size = 912787, upload-time = "2026-03-28T21:48:16.548Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ab/2c1bc8ab99f63cdabdbc7823af8f4cfcd6ddbb2babf01861826c3f1ad44d/regex-2026.3.32-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a094e9dcafedfb9d333db5cf880304946683f43a6582bb86688f123335122929", size = 800879, upload-time = "2026-03-28T21:48:18.971Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e5/0be716eb2c0b2ae3a439e44432534e82b2f81848af64cb21c0473ad8ae46/regex-2026.3.32-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c1cecea3e477af105f32ef2119b8d895f297492e41d317e60d474bc4bffd62ff", size = 776332, upload-time = "2026-03-28T21:48:21.163Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/114a61bd25dec7d1070930eaef82aadf9b05961a37629e7cca7bc3fc2257/regex-2026.3.32-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f26262900edd16272b6360014495e8d68379c6c6e95983f9b7b322dc928a1194", size = 786384, upload-time = "2026-03-28T21:48:23.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/78/be0a6531f8db426e8e60d6356aeef8e9cc3f541655a648c4968b63c87a88/regex-2026.3.32-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1cb22fa9ee6a0acb22fc9aecce5f9995fe4d2426ed849357d499d62608fbd7f9", size = 861381, upload-time = "2026-03-28T21:48:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b1/e5076fbe45b8fb39672584b1b606d512f5bd3a43155be68a95f6b88c1fc5/regex-2026.3.32-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9b9118a78e031a2e4709cd2fcc3028432e89b718db70073a8da574c249b5b249", size = 765434, upload-time = "2026-03-28T21:48:27.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/da/fd65d68b897f8b52b1390d20d776fa753582484724a9cb4f4c26de657ae5/regex-2026.3.32-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b193ed199848aa96618cd5959c1582a0bf23cd698b0b900cb0ffe81b02c8659c", size = 851501, upload-time = "2026-03-28T21:48:29.884Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d6/1e9c991c32022a9312e9124cc974961b3a2501338de2cd1cce75a3612d7a/regex-2026.3.32-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:10fb2aaae1aaadf7d43c9f3c2450404253697bf8b9ce360bd5418d1d16292298", size = 788076, upload-time = "2026-03-28T21:48:32.025Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5b/b23c72f6d607cbb24ef42acf0c7c2ef4eee1377a9f7ba43b312f889edfbb/regex-2026.3.32-cp314-cp314-win32.whl", hash = "sha256:110ba4920721374d16c4c8ea7ce27b09546d43e16aea1d7f43681b5b8f80ba61", size = 272255, upload-time = "2026-03-28T21:48:34.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ec/32bbcc42366097a8cea2c481e02964be6c6fa5ccfb0fa9581686af0bec5f/regex-2026.3.32-cp314-cp314-win_amd64.whl", hash = "sha256:245667ad430745bae6a1e41081872d25819d86fbd9e0eec485ba00d9f78ad43d", size = 281160, upload-time = "2026-03-28T21:48:36.588Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e4/89038a028cb68e719fa03ab1ad603649fc199bcda12270d2ac7b471b8f5d/regex-2026.3.32-cp314-cp314-win_arm64.whl", hash = "sha256:1ca02ff0ef33e9d8276a1fcd6d90ff6ea055a32c9149c0050b5b67e26c6d2c51", size = 273688, upload-time = "2026-03-28T21:48:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6e/87caccd608837a1fa4f8c7edc48e206103452b9bbc94fc724fa39340e807/regex-2026.3.32-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:51fb7e26f91f9091fd8ec6a946f99b15d3bc3667cb5ddc73dd6cb2222dd4a1cc", size = 494506, upload-time = "2026-03-28T21:48:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/16/53/a922e6b24694d70bdd68fc3fd076950e15b1b418cff9d2cc362b3968d86f/regex-2026.3.32-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:51a93452034d671b0e21b883d48ea66c5d6a05620ee16a9d3f229e828568f3f0", size = 293986, upload-time = "2026-03-28T21:48:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e4/0cb32203c1aebad0577fcd5b9af1fe764869e617d5234bc6a0ad284299ea/regex-2026.3.32-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:03c2ebd15ff51e7b13bb3dc28dd5ac18cd39e59ebb40430b14ae1a19e833cff1", size = 292677, upload-time = "2026-03-28T21:48:45.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f8/5006b70291469d4174dd66ad162802e2f68419c0f2a7952d0c76c1288cfa/regex-2026.3.32-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bf2f3c2c5bd8360d335c7dcd4a9006cf1dabae063ee2558ee1b07bbc8a20d88", size = 810661, upload-time = "2026-03-28T21:48:48.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9b/438763a20d22cd1f65f95c8f030dd25df2d80a941068a891d21a5f240456/regex-2026.3.32-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a4a3189a99ecdd1c13f42513ab3fc7fa8311b38ba7596dd98537acb8cd9acc3", size = 872156, upload-time = "2026-03-28T21:48:50.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5b/1341287887ac982ed9f5f60125e440513ffe354aa7e3681940495af7c12a/regex-2026.3.32-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c0bbfbd38506e1ea96a85da6782577f06239cb9fcf9696f1ea537c980c0680b", size = 916749, upload-time = "2026-03-28T21:48:53.57Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/1d2b48b8e94debfffc6fefb84d2a86a178cc208652a1d6493d5f29821c70/regex-2026.3.32-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8aaf8ee8f34b677f90742ca089b9c83d64bdc410528767273c816a863ed57327", size = 814788, upload-time = "2026-03-28T21:48:55.905Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d9/7dacb34c43adaeb954518d851f3e5d3ce495ac00a9d6010e3b4b59917c4a/regex-2026.3.32-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ea568832eca219c2be1721afa073c1c9eb8f98a9733fdedd0a9747639fc22a5", size = 786594, upload-time = "2026-03-28T21:48:58.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/72/28295068c92dbd6d3ce4fd22554345cf504e957cc57dadeda4a64fa86a57/regex-2026.3.32-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e4c8fa46aad1a11ae2f8fcd1c90b9d55e18925829ac0d98c5bb107f93351745", size = 800167, upload-time = "2026-03-28T21:49:01.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/17/b10745adeca5b8d52da050e7c746137f5d01dabc6dbbe6e8d9d821dc65c1/regex-2026.3.32-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cec365d44835b043d7b3266487797639d07d621bec9dc0ea224b00775797cc1", size = 865906, upload-time = "2026-03-28T21:49:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9d/1acbcce765044ac0c87f453f4876e0897f7a61c10315262f960184310798/regex-2026.3.32-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:09e26cad1544d856da85881ad292797289e4406338afe98163f3db9f7fac816c", size = 772642, upload-time = "2026-03-28T21:49:06.811Z" },
+    { url = "https://files.pythonhosted.org/packages/24/41/1ef8b4811355ad7b9d7579d3aeca00f18b7bc043ace26c8c609b9287346d/regex-2026.3.32-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:6062c4ef581a3e9e503dccf4e1b7f2d33fdc1c13ad510b287741ac73bc4c6b27", size = 856927, upload-time = "2026-03-28T21:49:09.373Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b1/0dc1d361be80ec1b8b707ada041090181133a7a29d438e432260a4b26f9a/regex-2026.3.32-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88ebc0783907468f17fca3d7821b30f9c21865a721144eb498cb0ff99a67bcac", size = 801910, upload-time = "2026-03-28T21:49:11.818Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/db/1a23f767fa250844772a9464306d34e0fafe2c317303b88a1415096b6324/regex-2026.3.32-cp314-cp314t-win32.whl", hash = "sha256:e480d3dac06c89bc2e0fd87524cc38c546ac8b4a38177650745e64acbbcfdeba", size = 275714, upload-time = "2026-03-28T21:49:14.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/2b/616d31b125ca76079d74d6b1d84ec0860ffdb41c379151135d06e35a8633/regex-2026.3.32-cp314-cp314t-win_amd64.whl", hash = "sha256:67015a8162d413af9e3309d9a24e385816666fbf09e48e3ec43342c8536f7df6", size = 285722, upload-time = "2026-03-28T21:49:16.642Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/91/043d9a00d6123c5fa22a3dc96b10445ce434a8110e1d5e53efb01f243c8b/regex-2026.3.32-cp314-cp314t-win_arm64.whl", hash = "sha256:1a6ac1ed758902e664e0d95c1ee5991aa6fb355423f378ed184c6ec47a1ec0e9", size = 275700, upload-time = "2026-03-28T21:49:19.348Z" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.33.0"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2275,9 +2290,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -2422,15 +2437,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/2f/9223c24f568bb7a0c03d751e609844dce0968f13b39a3f73fbb3a96cd27a/sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049", size = 32420, upload-time = "2026-03-17T20:05:55.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/e2/b8cff57a67dddf9a464d7e943218e031617fb3ddc133aeeb0602ff5f6c85/sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d", size = 14329, upload-time = "2026-03-17T20:05:54.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**What does this change?**

Closes #13. Adds per-task token usage and cost to build and audit output. Uses pydantic's `genai-prices` for cost calculation across all supported providers. Models not yet in the pricing database show `?` for cost but tokens are always displayed.

Also pinned `mistralai<2` because 2.x dropped the Mistral class that `pydantic-ai` imports.

Refactored `build_task` by extracting LLM agent and subprocess verification calls into a `BuildBackend` protocol (`DefaultBuildBackend`) to improve testability. Also enforced the `PLC0415` (import-outside-top-level) ruff rule in tests and cleaned up a circular import.

**How was it tested?**

Significant test expansion, New unit tests for `UsageTracker`, formatting helpers, tracker wiring, summary output, `build_task` orchestration (verify/fix loop), `_run_with_retry` error handling, and spec/cross-spec audit fixers.

Added additional integration tests for end-to-end workflows. 