### PR TITLE
feat: warn about high requirement complexity during validate

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -30,6 +30,8 @@ ossature validate
 
 Checks that every `@depends` target exists, every `@spec` reference in AMDs resolves to a real SMD, there are no duplicate component names within a spec, and there are no cycles in the dependency graph.
 
+If a spec has high requirement complexity, validate prints a warning. Validation still passes, but the spec may cause problems during plan generation. Consider splitting it into smaller specs linked with `@depends`.
+
 ## ossature audit
 
 The most complex command. Sends specs to the LLM for review, generates context files, and produces a build plan.

--- a/docs/specs/smd.md
+++ b/docs/specs/smd.md
@@ -133,6 +133,8 @@ You don't need formal requirement IDs like REQ-001. Just use descriptive heading
 
 Be specific about edge cases. If your spec says "handle invalid input" without explaining what that means, you'll get the LLM's best guess. If you say "empty category string prints error and exits with code 1", you'll get exactly that.
 
+If a spec gets too complex, plan generation can struggle with it. `ossature validate` warns you when this happens. Split the spec into smaller ones linked with `@depends`. A monolithic "backend" spec works better as separate specs for auth, database, and API.
+
 ## Next Steps
 
 - [AMD Format](amd.md) - Define architecture explicitly

--- a/src/ossature/cli/commands/validate.py
+++ b/src/ossature/cli/commands/validate.py
@@ -11,6 +11,8 @@ from ossature.models.smd import Priority, SMDSpec
 from ossature.parsers.amd import parse_amd_file
 from ossature.parsers.smd import parse_smd_file
 
+MAX_REQUIREMENT_COMPLEXITY = 3000
+
 STATUS_STYLE: dict[Status, str] = {
     Status.DRAFT: "dim",
     Status.REVIEW: "yellow",
@@ -159,6 +161,27 @@ def print_validation_summary(
         console.print(tbl)
 
 
+def _requirement_complexity(smd: SMDSpec) -> int:
+    return sum(
+        len(r.description)
+        + len(r.accepts)
+        + len(r.returns)
+        + sum(len(c) + len(m) for c, m in r.errors)
+        for r in smd.requirements
+    )
+
+
+def _warn_complex_specs(console: Console, parsed_smds: list[SMDSpec]) -> None:
+    for smd in parsed_smds:
+        complexity = _requirement_complexity(smd)
+        if complexity > MAX_REQUIREMENT_COMPLEXITY:
+            console.print(
+                f"\n[yellow]WARNING:[/] {smd.spec_id} has high requirement complexity. "
+                f"Complex specs may fail during planning.\n"
+                f"Consider splitting into multiple specs linked with @depends."
+            )
+
+
 def run_validate(
     config_path: Path,
     verbose: bool,
@@ -192,6 +215,7 @@ def run_validate(
         console.print()
         console.print("[green]✓[/green] All checks passed")
         print_validation_summary(console, parsed_smds=parsed_smds, parsed_amds=parsed_amds)
+        _warn_complex_specs(console, parsed_smds)
         return
 
     # Verbose path: show per-file progress, then delegate cross-reference checks
@@ -238,3 +262,4 @@ def run_validate(
         raise SystemExit(1) from None
 
     print_validation_summary(console, parsed_smds=parsed_smds, parsed_amds=parsed_amds)
+    _warn_complex_specs(console, parsed_smds)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -73,18 +73,27 @@ sample output
 
 
 def write_smd(
-    project_dir: Path, spec_id: str, title: str, overview: str = "Overview text.", depends: str = ""
+    project_dir: Path,
+    spec_id: str,
+    title: str,
+    overview: str = "Overview text.",
+    depends: str = "",
+    requirement_description: str = "",
 ) -> Path:
+    content = MINIMAL_SMD.format(
+        title=title,
+        spec_id=spec_id,
+        overview=overview,
+        depends=depends,
+    )
+    if requirement_description:
+        content = content.replace(
+            "Core requirement description.",
+            requirement_description,
+        )
     filename = f"{spec_id.lower()}.smd"
     filepath = project_dir / "specs" / filename
-    filepath.write_text(
-        MINIMAL_SMD.format(
-            title=title,
-            spec_id=spec_id,
-            overview=overview,
-            depends=depends,
-        )
-    )
+    filepath.write_text(content)
     return filepath
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -225,6 +225,42 @@ class TestValidateCommand:
         finally:
             os.chdir(old_cwd)
 
+    def test_complex_spec_warning(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "BIG", "Big Module", requirement_description="x" * 3100)
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "WARNING" in result.output
+        assert "BIG" in result.output
+        assert "high requirement complexity" in result.output
+        assert "Consider splitting" in result.output
+
+    def test_complex_spec_warning_verbose(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "BIG", "Big Module", requirement_description="x" * 3100)
+
+        result = run_in_project(runner, project_dir, ["-v", "validate"])
+
+        assert result.exit_code == 0
+        assert "WARNING" in result.output
+        assert "high requirement complexity" in result.output
+
+    def test_no_warning_at_threshold(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "OK", "Ok Module", requirement_description="x" * 2900)
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "WARNING" not in result.output
+
+    def test_no_warning_below_threshold(self, runner: CliRunner, project_dir: Path):
+        write_smd(project_dir, "SMALL", "Small Module")
+
+        result = run_in_project(runner, project_dir, ["validate"])
+
+        assert result.exit_code == 0
+        assert "WARNING" not in result.output
+
 
 class TestDetectCycle:
     def test_no_deps(self):


### PR DESCRIPTION
**What does this change?**

Resolves #14.

When a spec has a lot of detailed requirements, plan generation can fail because the LLM context becomes too long. Users may hit this easily with dense specs that have many long requirements.

Instead of counting requirements like suggested in #14 (which can produces false positives on specs with many but simple requirements), this PR introduces the idea of spec complexity score based on the total content size of all requirement fields (descriptions, accepts, returns, and error cases). The user gets a warning after validation success if the score exceeds the threshold. Validation still passes as normal, but the user gets a heads up.

The threshold was calibrated against Ossature's example projects to 3000 chars. May still need additional tuning in the future, but I think this is a good baseline for now.

**How was it tested?**

Added integration tests covering both verbose and non-verbose paths, boundary conditions at the threshold, and specs below it. Full test suite passes.