### PR TITLE
Preserve audit and planner prompts and responses

### DIFF
--- a/docs/advanced/build-system.md
+++ b/docs/advanced/build-system.md
@@ -14,7 +14,16 @@ All Ossature state lives in `.ossature/`. Here's what's inside after an audit an
 ├── plan.toml                  # The build plan (editable)
 ├── state.toml                 # Per-task input/output hashes
 ├── audits/
-│   └── EXPENSE_TRACKER.json   # Cached per-spec audit results
+│   ├── EXPENSE_TRACKER/
+│   │   ├── prompt.md          # Exact prompt sent to the auditor
+│   │   └── response.json      # Cached per-spec audit findings
+│   └── cross-spec/
+│       ├── prompt.md          # Exact prompt sent to the cross-spec auditor
+│       └── response.json      # Cached cross-spec audit findings
+├── planners/
+│   └── EXPENSE_TRACKER/
+│       ├── prompt.md          # Exact prompt sent to the planner
+│       └── response.json      # Raw per-spec task plan from the LLM
 ├── snapshots/
 │   └── EXPENSE_TRACKER.md     # Rendered spec content for diffing
 ├── context/

--- a/src/ossature/audit/audit.py
+++ b/src/ossature/audit/audit.py
@@ -28,6 +28,7 @@ def audit_spec(
     spec_id: str,
     amd_paths: list[Path] | None = None,
     tracker: UsageTracker | None = None,
+    transcript_dir: Path | None = None,
 ) -> SpecAuditReport:
     model = config.llm.model_for("audit")
     agent = Agent(
@@ -47,14 +48,20 @@ def audit_spec(
         for amd_path in amd_paths:
             sections.append(_read_numbered(amd_path))
 
+    user_prompt = "\n---\n".join(sections)
+
     result = run_agent_sync(
         agent,
-        "\n---\n".join(sections),
+        user_prompt,
         operation="spec audit",
         model_name=model,
         spec_id=spec_id,
         tracker=tracker,
     )
+
+    if transcript_dir is not None:
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "prompt.md").write_text(user_prompt)
 
     return result.output
 
@@ -64,6 +71,7 @@ def audit_cross_specs(
     parsed_smds: list[SMDSpec],
     parsed_amds: list[AMDSpec] | None = None,
     tracker: UsageTracker | None = None,
+    transcript_dir: Path | None = None,
 ) -> CrossSpecAuditReport:
     """
     Audit interfaces between interdependent specs.
@@ -149,30 +157,36 @@ def audit_cross_specs(
         tracker=tracker,
     )
 
+    if transcript_dir is not None:
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "prompt.md").write_text(audit_input)
+
     return result.output
 
 
 def save_spec_audit_data(report: SpecAuditReport, spec_id: str, audit_dir: Path) -> None:
-    audit_dir.mkdir(parents=True, exist_ok=True)
-    filepath = audit_dir / f"{spec_id}.json"
+    spec_dir = audit_dir / spec_id
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    filepath = spec_dir / "response.json"
     filepath.write_text(report.model_dump_json(indent=2))
 
 
 def load_spec_audit_data(spec_id: str, audit_dir: Path) -> SpecAuditReport | None:
-    filepath = audit_dir / f"{spec_id}.json"
+    filepath = audit_dir / spec_id / "response.json"
     if not filepath.exists():
         return None
     return SpecAuditReport.model_validate_json(filepath.read_text())
 
 
 def save_cross_spec_audit_data(report: CrossSpecAuditReport, audit_dir: Path) -> None:
-    audit_dir.mkdir(parents=True, exist_ok=True)
-    filepath = audit_dir / "cross-spec.json"
+    cross_dir = audit_dir / "cross-spec"
+    cross_dir.mkdir(parents=True, exist_ok=True)
+    filepath = cross_dir / "response.json"
     filepath.write_text(report.model_dump_json(indent=2))
 
 
 def load_cross_spec_audit_data(audit_dir: Path) -> CrossSpecAuditReport | None:
-    filepath = audit_dir / "cross-spec.json"
+    filepath = audit_dir / "cross-spec" / "response.json"
     if not filepath.exists():
         return None
     return CrossSpecAuditReport.model_validate_json(filepath.read_text())

--- a/src/ossature/audit/planner.py
+++ b/src/ossature/audit/planner.py
@@ -89,6 +89,7 @@ def generate_spec_plan(
     spec_diff: str | None = None,
     previous_tasks: list[PlanTask] | None = None,
     tracker: UsageTracker | None = None,
+    transcript_dir: Path | None = None,
 ) -> SpecTaskPlan:
     model = config.llm.model_for("planner")
     agent = Agent(
@@ -151,14 +152,21 @@ def generate_spec_plan(
             "wherever fits the project structure)."
         )
 
+    user_prompt = "\n".join(sections)
+
     result = run_agent_sync(
         agent,
-        "\n".join(sections),
+        user_prompt,
         operation="plan generation",
         model_name=model,
         spec_id=smd.spec_id,
         tracker=tracker,
     )
+
+    if transcript_dir is not None:
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "prompt.md").write_text(user_prompt)
+        (transcript_dir / "response.json").write_text(result.output.model_dump_json(indent=2))
 
     return result.output
 
@@ -307,6 +315,7 @@ def generate_plan(
                 spec_diff=spec_diff,
                 previous_tasks=previous_tasks,
                 tracker=tracker,
+                transcript_dir=config.metadata_planners_path / spec_id,
             )
             spec_plans[spec_id] = spec_plan
 

--- a/src/ossature/cli/commands/audit.py
+++ b/src/ossature/cli/commands/audit.py
@@ -404,7 +404,7 @@ def run_audit(
 
         for smd in parsed_smds:
             if smd.spec_id not in specs_to_audit:
-                audit_json = audit_data_dir / f"{smd.spec_id}.json"
+                audit_json = audit_data_dir / smd.spec_id / "response.json"
                 if not audit_json.exists():
                     specs_missing_audit.add(smd.spec_id)
 
@@ -472,7 +472,12 @@ def run_audit(
                         config.spec_path / rel for rel in amd_file_map.get(smd.spec_id, [])
                     ]
                     report = audit_spec(
-                        config, smd_path, smd.spec_id, spec_amd_paths or None, tracker=audit_usage
+                        config,
+                        smd_path,
+                        smd.spec_id,
+                        spec_amd_paths or None,
+                        tracker=audit_usage,
+                        transcript_dir=audit_data_dir / smd.spec_id,
                     )
                     save_spec_audit_data(report, smd.spec_id, audit_data_dir)
                     spec_reports[smd.spec_id] = report
@@ -579,7 +584,11 @@ def run_audit(
                         status.update(f"Cross-spec audit - {config.name} v{config.version}")
 
                     cross_spec_report = audit_cross_specs(
-                        config, parsed_smds, parsed_amds, tracker=audit_usage
+                        config,
+                        parsed_smds,
+                        parsed_amds,
+                        tracker=audit_usage,
+                        transcript_dir=audit_data_dir / "cross-spec",
                     )
                     save_cross_spec_audit_data(cross_spec_report, audit_data_dir)
 

--- a/src/ossature/config/loader.py
+++ b/src/ossature/config/loader.py
@@ -126,6 +126,10 @@ class OssatureConfig:
         return self.metadata_path / "snapshots"
 
     @property
+    def metadata_planners_path(self) -> Path:
+        return self.metadata_path / "planners"
+
+    @property
     def is_audited(self) -> bool:
         return self.metadata_path.exists()
 

--- a/tests/unit/test_audit_io.py
+++ b/tests/unit/test_audit_io.py
@@ -65,7 +65,7 @@ class TestSpecAuditDataIO:
         save_spec_audit_data(report, "TEST", audit_dir)
 
         assert audit_dir.exists()
-        assert (audit_dir / "TEST.json").exists()
+        assert (audit_dir / "TEST" / "response.json").exists()
 
 
 class TestCrossSpecAuditDataIO:


### PR DESCRIPTION
**What does this change?**

Resolves #45

Persists the prompts (and per-spec response JSON) for audit and planner LLM calls, similar to how we currently save tasks' `prompt.md`/`response.md` during build.

New layout under `.ossature/`:

- `audits/<SPEC>/prompt.md` and `response.json`: per-spec audit (`response.json` replaces the old `audits/<SPEC>.json`)
- `audits/cross-spec/prompt.md` and `response.json`: cross-spec audit (`response.json` replaces the old `audits/cross-spec.json`)
- `planners/<SPEC>/prompt.md` and `response.json`: per-spec planner output (raw `SpecTaskPlan` from the LLM)

**How was it tested?**

All tests pass. Tested manually on example projects.
