### PR TITLE
fix: pre-flight check flags binaries produced earlier in verify pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,41 @@ jobs:
 
       - run: make test-cov
 
-      - name: Upload coverage reports to Codecov
+      - name: Upload unit coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ossature/ossature
+          files: coverage-unit.xml
+          flags: unit
           fail_ci_if_error: false
+
+      - name: Upload integration coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ossature/ossature
+          files: coverage-integration.xml
+          flags: integration
+          fail_ci_if_error: false
+
+      - name: Upload unit test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ossature/ossature
+          files: junit-unit.xml
+          flags: unit
+
+      - name: Upload integration test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ossature/ossature
+          files: junit-integration.xml
+          flags: integration
 
       - uses: actions/upload-artifact@v6
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ htmlcov/
 .coverage.*
 .cache
 coverage.xml
+coverage-unit.xml
+coverage-integration.xml
+junit.xml
+junit-unit.xml
+junit-integration.xml
 *.cover
 *.py,cover
 .pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-Spec metadata moved from inline `@key: value` lines to YAML frontmatter delimited with `---`. The custom format was nice for keeping the document feel readable on its own, but editors didn't recognize it and you couldn't get any tooling for free. Frontmatter is the convention most Markdown ecosystems already understand, so opening a `.smd` in any decent editor now syntax-highlights the metadata block without extra setup. The format inside the block is the same, just without the `@` prefix and wrapped in fences. The old format isn't supported anymore, so existing 0.0.4 specs need to be converted by hand.
+Spec metadata now uses standard YAML frontmatter (`---` delimited) instead of the custom `@key: value` format. The `verify`, `setup`, and `test` fields are now lists of shell commands rather than single strings, improving readability for multi-step jobs. The pre-flight tool check was simplified: commands with `/` in the name are treated as project artifacts and skipped, fixing false positives for patterns like make `&& ./myapp`. The planner prompt now scopes `verify` to each task's own outputs, using lightweight checks for scaffold tasks that don't yet have buildable source.
 
 ### Changed
 
@@ -14,6 +14,13 @@ Spec metadata moved from inline `@key: value` lines to YAML frontmatter delimite
 - `render_smd` and `render_amd` emit a `---` delimited frontmatter block before the H1 title.
 - `ossature new` scaffolds new specs using the new format.
 - The fixer prompt was updated so the LLM knows to leave the frontmatter alone unless a finding requires editing it.
+- `PlanTask.verify`, `PlannerTask.verify`, and `BuildConfig.{setup, verify, test}` are now `list[str]`. Bare strings in existing `plan.toml` and `ossature.toml` files get coerced on load, so older files keep working.
+- `run_setup` and `run_verify` iterate the command list, run each step in its own shell, stop on the first non-zero exit, and prefix multi-step output with `$ <command>` headers so failures are self-describing.
+- The planner prompt tells the LLM to emit `verify` as a list, scope each step to the task's own outputs, and use lightweight checks for scaffold-only tasks. New examples cover both the scaffold case and the dependent compile-and-run case.
+
+### Fixed
+
+- `ossature build`'s pre-flight tool check no longer flags binaries produced earlier in the same verify pipeline as missing PATH dependencies. This affected any `compile && ./run` pattern (gcc with a binary, make with `./binary`, cargo build with `target/release/x`, and so on) regardless of language or build system.
 
 ## 0.0.4 - 2026-04-30
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ test:
 	uv run pytest tests/ -v $(ARGS)
 
 test-cov:
-	uv run pytest tests/ --cov=src/ossature --cov-report=term-missing --cov-report=html --cov-report=xml
+	rm -f .coverage
+	uv run pytest tests/unit --cov=src/ossature --cov-report=xml:coverage-unit.xml --junitxml=junit-unit.xml -o junit_family=legacy
+	uv run pytest tests/integration --cov=src/ossature --cov-append --cov-report=term-missing --cov-report=html --cov-report=xml:coverage-integration.xml --junitxml=junit-integration.xml -o junit_family=legacy
 
 check: lint typecheck test
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,94 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+      unit:
+        target: auto
+        threshold: 1%
+        flags:
+          - unit
+      integration:
+        target: auto
+        threshold: 1%
+        flags:
+          - integration
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_flags:
+    - name: unit
+      paths:
+        - src/ossature/
+    - name: integration
+      paths:
+        - src/ossature/
+
+comment:
+  layout: "header, diff, flags, components, files, footer"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "src/ossature/__init__.py"
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: audit
+      name: audit
+      paths:
+        - src/ossature/audit/**
+    - component_id: build
+      name: build
+      paths:
+        - src/ossature/build/**
+    - component_id: cli
+      name: cli
+      paths:
+        - src/ossature/cli/**
+    - component_id: config
+      name: config
+      paths:
+        - src/ossature/config/**
+    - component_id: models
+      name: models
+      paths:
+        - src/ossature/models/**
+    - component_id: parsers
+      name: parsers
+      paths:
+        - src/ossature/parsers/**
+    - component_id: renderer
+      name: renderer
+      paths:
+        - src/ossature/renderer/**
+    - component_id: shared
+      name: shared
+      paths:
+        - src/ossature/shared/**
+    - component_id: templates
+      name: templates
+      paths:
+        - src/ossature/templates/**

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,9 @@
     "webui",
     "sandboxed",
     "recompiles",
-    "frontmatter"
+    "frontmatter",
+    "CFLAGS",
+    "Wextra",
+    "myapp"
   ]
 }

--- a/docs/advanced/build-system.md
+++ b/docs/advanced/build-system.md
@@ -64,7 +64,7 @@ depends_on = []
 spec_refs = ["Goals", "Constraints"]
 arch_refs = ["Dependencies"]
 status = "pending"
-verify = "uv run python -c 'import spenny'"
+verify = ["uv run python -c 'import spenny'"]
 
 [[task]]
 id = "002"
@@ -74,8 +74,21 @@ outputs = ["src/spenny/storage.py"]
 depends_on = ["001"]
 inject_files = ["pyproject.toml", "src/spenny/__init__.py"]
 status = "pending"
-verify = "uv run python -c 'from spenny.storage import load, save'"
+verify = ["uv run python -c 'from spenny.storage import load, save'"]
 ```
+
+`verify` is a list of shell commands. Each step runs in its own shell, in order, and the task fails on the first non-zero exit. Multi-step pipelines stay readable as a list rather than a long `&&`-chained string:
+
+```toml
+verify = [
+    "make clean",
+    "make CFLAGS='-std=c99 -Wall -Wextra -pedantic'",
+    "./myapp --help > /tmp/help.txt",
+    "grep -q -- '--help' /tmp/help.txt",
+]
+```
+
+A bare string still loads for backwards compatibility, so `verify = "make"` is treated the same as `verify = ["make"]`.
 
 The plan is human-readable and human-editable. After `ossature audit` generates it, you can reorder tasks, add notes, skip tasks, or insert manual steps before running `ossature build`.
 
@@ -100,6 +113,22 @@ For each task in the plan:
 6. If the task succeeds, record input/output hashes in `state.toml`
 
 All file operations by the LLM are sandboxed to the output directory. Attempts to write outside it or use path traversal get rejected, and the LLM is told to try again.
+
+## Pre-Flight Tool Check
+
+Before the build runs any task, Ossature scans every `verify`, `setup`, and `test` command across the plan and checks that each tool the shell would look up on `PATH` is actually installed. The point is to fail fast when something like `cargo`, `make`, `gcc`, `npm`, or `zig` is missing, instead of burning LLM tokens generating code that can't be verified.
+
+The rule for what counts as a tool we need on `PATH` is the POSIX one. The shell only consults `PATH` when the command name contains no `/`. So `make` and `cargo` get checked. Anything with a slash, like `./myapp`, `target/release/foo`, `zig-out/bin/x`, `node_modules/.bin/eslint`, or `/tmp/test_bin`, is invoked by direct file path. Those are project artifacts, not tools, so we leave them alone. This works the same way for any language or build system, with no compiler-specific logic to maintain.
+
+If any required tool is missing, the build prints the missing names and the verify lines that referenced them, then exits before the first LLM call.
+
+## Per-Task Verify Scoping
+
+A task's `verify` runs immediately after that task completes. Earlier tasks listed in `depends_on` have already run, but later tasks have not. So the verify can only exercise things that already exist at that point. Files this task or its dependencies produced are fair game, but files a later task is going to write are not.
+
+The most common trap is a scaffolding task that only emits a build config like a Makefile, `package.json`, `Cargo.toml`, `build.zig`, or `CMakeLists.txt` before any source exists. If you set that task's verify to `make` or `cargo build`, it'll fail because the source the build references is produced by a later task. The Makefile itself is fine, the build just has nothing to compile yet. For scaffold-only tasks, use lightweight checks. File existence (`test -f Makefile`) is usually enough, sometimes a parse or syntax check, or a dry-run of a target that doesn't depend on the source. Save the full build for the task that actually writes the source, and make sure that task lists the scaffold task in its `depends_on`.
+
+The planner is told about this scoping rule when it generates the plan, and should produce sensible verify commands by default. When you edit `plan.toml` by hand, the same rule applies.
 
 ## The Fix Loop
 

--- a/docs/configuration/ossature-toml.md
+++ b/docs/configuration/ossature-toml.md
@@ -55,14 +55,25 @@ Controls how many times the audit will attempt to fix errors in a spec and re-au
 
 ```toml
 [build]
-max_fix_attempts = 3     # verify-fail → fix → re-verify cycles per task
-max_inline_lines = 200   # files above this aren't inlined in fix prompts
-setup = "cargo init"     # optional: run before the first task
-verify = "cargo check"   # optional: override default verification command
-test = "cargo test"      # optional: override default test command
+max_fix_attempts = 3                  # verify-fail → fix → re-verify cycles per task
+max_inline_lines = 200                # files above this aren't inlined in fix prompts
+setup = ["cargo init"]                # optional: run before the first task
+verify = ["cargo check"]              # optional: override default verification
+test = ["cargo test"]                 # optional: override default test command
 ```
 
-The `setup` command runs once before the first build task. Useful for project initialization that the LLM shouldn't handle.
+The `setup`, `verify`, and `test` fields are lists of shell commands. Each list item runs in its own shell, in order, and the build stops as soon as any command exits non-zero. A bare string is also accepted for backwards compatibility, so `verify = "cargo check"` keeps working and is treated the same as `verify = ["cargo check"]`. New configs should use lists. They're easier to read for multi-step pipelines and the pre-flight tool check can look at each step on its own.
+
+```toml
+[build]
+verify = [
+    "gcc -Wall -o /tmp/build_check sample.c",
+    "/tmp/build_check --help > /dev/null",
+    "/tmp/build_check --version > /dev/null",
+]
+```
+
+The `setup` commands run once before the first build task. Useful for project initialization that the LLM shouldn't handle.
 
 The `verify` and `test` commands override what Ossature uses to check generated code. If not set, the LLM determines verification commands per task based on the language and project structure.
 

--- a/docs/getting-started/workflow.md
+++ b/docs/getting-started/workflow.md
@@ -22,8 +22,8 @@ dir = "output"
 language = "rust"
 
 [build]
-setup = "cargo init --name markman"
-verify = "cargo check"
+setup = ["cargo init --name markman"]
+verify = ["cargo check"]
 
 [llm]
 model = "anthropic:claude-haiku-4-5-20251001"
@@ -177,7 +177,7 @@ outputs = ["src/storage.rs"]
 depends_on = []
 spec_refs = ["Overview", "Requirements > Add Bookmark", ...]
 status = "pending"
-verify = "cargo check"
+verify = ["cargo check"]
 
 [[task]]
 id = "002"
@@ -187,7 +187,7 @@ outputs = ["src/storage.rs"]
 depends_on = ["001"]
 inject_files = ["src/storage.rs"]
 status = "pending"
-verify = "cargo check"
+verify = ["cargo check"]
 ```
 
 Things worth checking: whether dependencies make sense and tasks are in a reasonable order, whether tasks are too broad (touching too many files) or too narrow, whether `spec_refs` is pulling the right spec sections into each task's prompt, and whether verify commands will actually catch problems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "S", "SIM", "PT", "RUF", "C4", "PI
 ignore = ["S602", "S110", "S310"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101"]
+"tests/**/*.py" = ["S101", "S108"]
 "src/**/*.py" = ["PLC0415"]
 
 [tool.mypy]

--- a/src/ossature/audit/planner.py
+++ b/src/ossature/audit/planner.py
@@ -94,7 +94,12 @@ def _format_previous_tasks(tasks: list[PlanTask]) -> str:
             lines.append(f"- spec_refs: {task.spec_refs}")
         if task.arch_refs:
             lines.append(f"- arch_refs: {task.arch_refs}")
-        lines.append(f"- verify: {task.verify}")
+        if not task.verify:
+            lines.append("- verify: ")
+        elif len(task.verify) == 1:
+            lines.append(f"- verify: {task.verify[0]}")
+        else:
+            lines.append(f"- verify: {task.verify}")
         if task.context_files:
             lines.append(f"- context_files: {task.context_files}")
         lines.append("")
@@ -128,7 +133,7 @@ def _resolve_preserved_refs(
                     depends_on=task.depends_on,
                     spec_refs=[],
                     arch_refs=[],
-                    verify="true",
+                    verify=["true"],
                 )
             )
             continue

--- a/src/ossature/audit/prompts.py
+++ b/src/ossature/audit/prompts.py
@@ -186,7 +186,13 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     "6. Do not reorder, split, or merge unaffected tasks.\n\n"
     "Before finalizing, verify that your dependency ordering is valid: no task should "
     "depend on a task that comes after it, and no task should reference files that "
-    "haven't been produced by an earlier task.\n"
+    "haven't been produced by an earlier task. In particular, walk each task's "
+    "`verify` commands and confirm every file, binary, target, and symbol they "
+    "touch is produced either by THIS task or by one of its `depends_on` "
+    "predecessors — never by a task that runs later. If a scaffold task creates "
+    "only a build config (Makefile, package.json, build.zig, …) and the "
+    "compilable source lives in a later task, the scaffold's `verify` MUST NOT "
+    "invoke the build.\n"
     "</instructions>\n\n"
     "<output_format>\n"
     "Output the tasks as a structured list. Each task needs:\n"
@@ -198,7 +204,34 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     "- spec_refs: list of spec section names relevant to this task\n"
     "- arch_refs: list of architecture section names relevant to this task "
     "(empty if no AMD provided)\n"
-    "- verify: shell command to verify the output compiles/passes\n"
+    "- verify: list of shell commands to run in order to verify THIS task's "
+    "output. The build fails as soon as any command returns non-zero. "
+    "Use one command per logical step (e.g. compile in one step, run the binary "
+    "in the next) — do not chain steps with `&&` inside a single string. "
+    "Reference any binary you produce by its path (e.g. `./my_binary`, "
+    "`target/release/foo`, `zig-out/bin/x`) so the shell invokes it by file "
+    "path rather than via PATH.\n"
+    "  Critical scoping rules for verify:\n"
+    "  * verify runs immediately after THIS task completes. Earlier tasks have "
+    "run; later tasks have NOT. Never reference files, targets, or symbols that "
+    "this task and its `depends_on` predecessors don't produce.\n"
+    "  * For scaffolding tasks that only emit a build config or manifest "
+    "(Makefile, package.json, Cargo.toml, build.zig, CMakeLists.txt, pyproject.toml, "
+    "tsconfig.json, …) and do not yet emit source files, do NOT invoke the build "
+    "(no `make`, `cargo build`, `npm run build`, `zig build`, `cmake --build`, "
+    "etc.) — those will fail because the source the build references doesn't "
+    "exist yet. Instead use lightweight checks that exercise only the file you "
+    "wrote: a parse/syntax check (e.g. `python -m json.tool < package.json > /dev/null`, "
+    "`cargo metadata --no-deps --manifest-path Cargo.toml --format-version 1 > /dev/null` "
+    "ONLY if a source stub also exists, otherwise just `test -f Makefile`), a "
+    "dry-run of a target that doesn't depend on unbuilt source (e.g. `make -n help` "
+    'only if you defined a `help` target), or simply `["test -f <path>"]` if no '
+    "richer check is safe.\n"
+    "  * If you cannot devise a useful verify that succeeds with only this task's "
+    'outputs in place, prefer `["test -f <output>"]` or omit the verify entirely '
+    "(empty list) over emitting a command that will fail because of missing future "
+    "files. Verify must reflect what is verifiable NOW, not what the project will "
+    "be able to do later.\n"
     "- context_files: list of filenames from the context directory that this task needs "
     "(empty if none). Only assign files that are directly relevant to the task.\n"
     "</output_format>\n\n"
@@ -212,7 +245,33 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     "depends_on: [1]\n"
     'spec_refs: ["overview", "Requirements > Token Format"]\n'
     'arch_refs: ["data models", "Components > TokenManager"]\n'
-    'verify: "cargo check"\n'
+    'verify: ["cargo check"]\n'
+    "context_files: []\n"
+    "</example>\n"
+    "<example>\n"
+    "A scaffolding-only task that emits a Makefile before any C source exists. "
+    "The Makefile references `yep.c`, but `yep.c` is produced by a later task — "
+    "so we do NOT invoke `make` here. We only confirm the Makefile was written:\n\n"
+    'title: "Scaffold Makefile build targets"\n'
+    'description: "Create the project Makefile with default and clean targets."\n'
+    'outputs: ["Makefile"]\n'
+    "depends_on: []\n"
+    'spec_refs: ["Build System"]\n'
+    "arch_refs: []\n"
+    'verify: ["test -f Makefile"]\n'
+    "context_files: []\n"
+    "</example>\n"
+    "<example>\n"
+    "A C task that compiles and then exercises the produced binary. This task "
+    "depends on the Makefile-scaffold task above, so `make` is safe to invoke:\n\n"
+    'title: "yep: CLI entrypoint"\n'
+    'description: "Implement the main entrypoint and basic --help/--version handling."\n'
+    'outputs: ["yep.c"]\n'
+    "depends_on: [1]\n"
+    'spec_refs: ["overview", "Requirements > CLI"]\n'
+    "arch_refs: []\n"
+    'verify: ["make clean", "make", "./yep --help > /dev/null", '
+    '"./yep --version > /dev/null"]\n'
     "context_files: []\n"
     "</example>\n"
     "</examples>"

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -776,27 +776,50 @@ def is_verify_command_error(error_output: str, output_dir: Path) -> bool:
     return has_invocation_signal and not has_source_ref
 
 
-def run_verify(command: str, cwd: Path) -> tuple[bool, str]:
-    try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            errors="replace",
-            cwd=str(cwd),
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        return False, "Verify command timed out after 120 seconds"
-    output = ""
-    if result.stdout:
-        output += result.stdout
-    if result.stderr:
-        if output:
-            output += "\n"
-        output += result.stderr
-    return result.returncode == 0, output.strip()
+def run_verify(commands: list[str], cwd: Path) -> tuple[bool, str]:
+    """Run verify commands in order, fail-fast on first non-zero exit.
+
+    Each command runs in a fresh shell. Output from successive commands
+    is concatenated (with command headers) so failures in any step are
+    self-describing.
+    """
+    if not commands:
+        return True, ""
+
+    combined: list[str] = []
+    for command in commands:
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                errors="replace",
+                cwd=str(cwd),
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            return False, "Verify command timed out after 120 seconds"
+
+        step_output = ""
+        if result.stdout:
+            step_output += result.stdout
+        if result.stderr:
+            if step_output:
+                step_output += "\n"
+            step_output += result.stderr
+        step_output = step_output.strip()
+
+        if len(commands) > 1:
+            header = f"$ {command}"
+            combined.append(header if not step_output else f"{header}\n{step_output}")
+        elif step_output:
+            combined.append(step_output)
+
+        if result.returncode != 0:
+            return False, "\n".join(combined).strip()
+
+    return True, "\n".join(combined).strip()
 
 
 # Task building
@@ -889,11 +912,20 @@ def _print_verify_errors(console: Console, verify_output: str) -> None:
     )
 
 
+def _format_verify_for_display(commands: list[str]) -> str:
+    """Render a verify command list as a single string for status/error messages."""
+    if not commands:
+        return ""
+    if len(commands) == 1:
+        return commands[0]
+    return " && ".join(commands)
+
+
 def _print_verify_command_error(console: Console, task: PlanTask, verify_output: str) -> None:
     truncated = _truncate_output(verify_output)
     body = (
         f"The verify command itself appears to be invalid — this is not a code error.\n\n"
-        f"  Command: [bold]{task.verify}[/bold]\n\n"
+        f"  Command: [bold]{_format_verify_for_display(task.verify)}[/bold]\n\n"
         f"{truncated}\n\n"
         f"Update the [cyan]verify[/cyan] field for task [bold]{task.id}[/bold] "
         "in [cyan].ossature/plan.toml[/cyan], then run "
@@ -952,7 +984,7 @@ class BuildBackend(Protocol):
         model_name: str,
     ) -> str: ...
 
-    def verify(self, command: str, cwd: Path) -> tuple[bool, str]: ...
+    def verify(self, commands: list[str], cwd: Path) -> tuple[bool, str]: ...
 
 
 class DefaultBuildBackend:
@@ -989,8 +1021,8 @@ class DefaultBuildBackend:
         output: str = result.output
         return output
 
-    def verify(self, command: str, cwd: Path) -> tuple[bool, str]:
-        return run_verify(command, cwd)
+    def verify(self, commands: list[str], cwd: Path) -> tuple[bool, str]:
+        return run_verify(commands, cwd)
 
 
 def build_task(
@@ -1048,8 +1080,10 @@ def build_task(
         save_task_output(task_dir, build_ctx.created_files, build_ctx.edited_files, True, "")
         return _make_result(True)
 
+    verify_label = _format_verify_for_display(task.verify)
+
     # Verification
-    build_ctx.set_phase(f"-- verifying ({task.verify})")
+    build_ctx.set_phase(f"-- verifying ({verify_label})")
     passed, verify_output = backend.verify(task.verify, config.output_path)
 
     if passed:
@@ -1071,7 +1105,7 @@ def build_task(
     attempt = 0
     while attempt < config.build.max_fix_attempts:
         build_ctx.set_phase(f"-- fixing ({attempt + 1}/{config.build.max_fix_attempts})")
-        fix_prompt = assemble_fix_prompt(task, verify_output, config, task.verify)
+        fix_prompt = assemble_fix_prompt(task, verify_output, config, verify_label)
         (task_dir / f"fix-{attempt + 1}-prompt.md").write_text(fix_prompt)
 
         # Snapshot file lists to detect no-op responses
@@ -1116,7 +1150,7 @@ def build_task(
                 attempt += 1
                 continue
 
-        build_ctx.set_phase(f"-- re-verifying ({task.verify})")
+        build_ctx.set_phase(f"-- re-verifying ({verify_label})")
         passed, verify_output = backend.verify(task.verify, config.output_path)
         if passed:
             save_task_output(
@@ -1260,109 +1294,148 @@ def run_setup(config: OssatureConfig, console: Console) -> bool:
     if not config.build.setup:
         return True
 
-    console.print(f"  Running setup: [bold]{config.build.setup}[/bold]")
-    try:
-        result = subprocess.run(
-            config.build.setup,
-            shell=True,
-            capture_output=True,
-            text=True,
-            errors="replace",
-            cwd=str(config.output_path),
-            timeout=300,
-        )
-    except subprocess.TimeoutExpired:
-        console.print("[red]Setup command timed out after 300 seconds.[/red]")
-        return False
-
-    if result.returncode != 0:
-        output = ""
-        if result.stdout:
-            output += result.stdout
-        if result.stderr:
-            if output:
-                output += "\n"
-            output += result.stderr
-        console.print(f"[red]Setup command failed (exit {result.returncode}):[/red]")
-        if output.strip():
-            console.print(
-                Panel(
-                    _truncate_output(output.strip()),
-                    border_style="red",
-                    expand=True,
-                    padding=(0, 1),
-                )
+    for command in config.build.setup:
+        console.print(f"  Running setup: [bold]{command}[/bold]")
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                errors="replace",
+                cwd=str(config.output_path),
+                timeout=300,
             )
-        return False
+        except subprocess.TimeoutExpired:
+            console.print("[red]Setup command timed out after 300 seconds.[/red]")
+            return False
+
+        if result.returncode != 0:
+            output = ""
+            if result.stdout:
+                output += result.stdout
+            if result.stderr:
+                if output:
+                    output += "\n"
+                output += result.stderr
+            console.print(f"[red]Setup command failed (exit {result.returncode}):[/red]")
+            if output.strip():
+                console.print(
+                    Panel(
+                        _truncate_output(output.strip()),
+                        border_style="red",
+                        expand=True,
+                        padding=(0, 1),
+                    )
+                )
+            return False
 
     console.print("  [green]Setup complete.[/green]")
     return True
 
 
-def _extract_commands_from_plan(plan: Plan, config: OssatureConfig) -> set[str]:
-    commands: set[str] = set()
+# Shell operators that delimit sub-commands within a single shell string.
+_SHELL_OPERATORS: frozenset[str] = frozenset({"&&", "||", ";", "|"})
 
+# Shell builtins whose first-token presence does not require a binary on PATH.
+_SHELL_BUILTINS: frozenset[str] = frozenset(
+    {"cd", "echo", "export", "test", "[", "true", "false", ":", "exit", "set", "unset"}
+)
+
+
+def _command_groups_from_plan(plan: Plan, config: OssatureConfig) -> list[list[str]]:
+    """Collect verify/setup/test command lists into per-scope groups.
+
+    Each group is a list of shell-command strings that share a sequential
+    execution context — outputs produced by an earlier item in the group
+    are visible to later items, but not across groups.
+    """
+    groups: list[list[str]] = []
     if config.build.setup:
-        commands.add(config.build.setup)
+        groups.append(list(config.build.setup))
     if config.build.verify:
-        commands.add(config.build.verify)
+        groups.append(list(config.build.verify))
     if config.build.test:
-        commands.add(config.build.test)
-
+        groups.append(list(config.build.test))
     for task in plan.tasks:
         if task.verify:
-            commands.add(task.verify)
+            groups.append(list(task.verify))
+    return groups
 
-    return commands
+
+def _split_tokens(command: str) -> list[str]:
+    """Tokenize a shell command, falling back to whitespace split on bad quoting."""
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
 
 
-def _extract_executables(commands: set[str]) -> set[str]:
-    executables: set[str] = set()
-    for cmd in commands:
-        # Use shlex to split respecting quotes, then identify command
-        # boundaries by looking for shell operators as standalone tokens.
-        try:
-            tokens = shlex.split(cmd)
-        except ValueError:
-            # Malformed quoting — fall back to naive split on whitespace
-            tokens = cmd.split()
+def _extract_executables_for_group(group: list[str]) -> dict[str, str]:
+    """Return a mapping of ``executable -> originating command`` for the group.
 
-        # Walk tokens, extracting the first word of each sub-command.
-        # Shell operators (&&, ||, ;) delimit sub-commands.
+    The check we perform is intentionally narrow and language-agnostic:
+    we flag only tokens the shell would actually resolve via ``PATH``.
+    Per POSIX, ``PATH`` is consulted **only** when the command name
+    contains no ``/``. Anything with a slash (``./yep``,
+    ``target/release/foo``, ``build/x``, ``zig-out/bin/x``,
+    ``node_modules/.bin/foo``, ``/tmp/x`` …) is invoked by direct file
+    path and bypasses ``PATH`` entirely — these are project artifacts,
+    not tools the user has to install.
+
+    For each command in the group:
+      1. Tokenize with ``shlex``.
+      2. Split on ``&&``/``||``/``;``/``|`` to find sub-command starts.
+      3. Skip env-var assignments (``FOO=bar cmd``) and known builtins.
+      4. Skip any token containing ``/`` — it's a path, not a PATH lookup.
+      5. Record the first qualifying token of each sub-command as a
+         required executable.
+    """
+    executables: dict[str, str] = {}
+
+    for command in group:
+        tokens = _split_tokens(command)
+
         expect_command = True
         for token in tokens:
-            if token in ("&&", "||", ";", "|"):
+            if token in _SHELL_OPERATORS:
                 expect_command = True
                 continue
             if not expect_command:
                 continue
-            # Skip environment variable assignments (e.g., FOO=bar cmd)
+            # Env-var assignments (FOO=bar cmd ...) — keep looking.
             if "=" in token and not token.startswith("="):
                 continue
-            # Skip common shell builtins
-            if token in ("cd", "echo", "export", "test", "[", "true", "false"):
+            # Shell builtins consume the command position but need no PATH.
+            if token in _SHELL_BUILTINS:
                 expect_command = False
                 continue
-            executables.add(token)
+            # Path-based invocations bypass PATH; treat the position as
+            # consumed and move on.
+            if "/" in token:
+                expect_command = False
+                continue
+            executables.setdefault(token, command)
             expect_command = False
+
     return executables
 
 
 def check_tool_availability(plan: Plan, config: OssatureConfig, console: Console) -> bool:
-    commands = _extract_commands_from_plan(plan, config)
-    if not commands:
+    groups = _command_groups_from_plan(plan, config)
+    if not groups:
         return True
 
-    executables = _extract_executables(commands)
-    if not executables:
-        return True
+    # exe -> ordered, deduplicated list of originating command strings
+    missing: dict[str, list[str]] = {}
 
-    missing: list[tuple[str, list[str]]] = []
-    for exe in sorted(executables):
-        if not shutil.which(exe):
-            # Find which commands reference this executable
-            referencing = [cmd for cmd in commands if exe in cmd.split()]
-            missing.append((exe, referencing))
+    for group in groups:
+        for exe, cmd in _extract_executables_for_group(group).items():
+            if shutil.which(exe):
+                continue
+            cmds = missing.setdefault(exe, [])
+            if cmd not in cmds:
+                cmds.append(cmd)
 
     if not missing:
         return True
@@ -1370,9 +1443,9 @@ def check_tool_availability(plan: Plan, config: OssatureConfig, console: Console
     console.print()
     console.print("[bold red]Missing required tools[/bold red]")
     console.print()
-    for exe, referencing in missing:
+    for exe in sorted(missing):
         console.print(f"  [red]x[/red] [bold]{exe}[/bold] not found on PATH")
-        for cmd in referencing:
+        for cmd in missing[exe]:
             console.print(f"    used by: [dim]{cmd}[/dim]")
     console.print()
     console.print("Install the missing tools before running the build to avoid wasting LLM tokens.")

--- a/src/ossature/config/loader.py
+++ b/src/ossature/config/loader.py
@@ -34,9 +34,9 @@ class AuditConfig:
 class BuildConfig:
     max_fix_attempts: int = 3
     max_inline_lines: int = 200
-    setup: str | None = None
-    verify: str | None = None
-    test: str | None = None
+    setup: list[str] = field(default_factory=list)
+    verify: list[str] = field(default_factory=list)
+    test: list[str] = field(default_factory=list)
 
 
 DEFAULT_MODEL = "anthropic:claude-sonnet-4-6"
@@ -172,13 +172,31 @@ def _parse_audit_config(data: dict[str, Any]) -> AuditConfig:
     )
 
 
+def _coerce_command_list(value: Any) -> list[str]:
+    """Normalize a build-command field to a list of command strings.
+
+    Accepts a single shell-command string (legacy form) or a list of
+    strings. An empty/missing value becomes an empty list so absence is
+    represented uniformly.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    raise ConfigError(
+        f"build command must be a string or a list of strings, got {type(value).__name__}"
+    )
+
+
 def _parse_build_config(data: dict[str, Any]) -> BuildConfig:
     return BuildConfig(
         max_fix_attempts=int(data.get("max_fix_attempts", 3)),
         max_inline_lines=int(data.get("max_inline_lines", 200)),
-        setup=data.get("setup"),
-        verify=data.get("verify"),
-        test=data.get("test"),
+        setup=_coerce_command_list(data.get("setup")),
+        verify=_coerce_command_list(data.get("verify")),
+        test=_coerce_command_list(data.get("test")),
     )
 
 
@@ -253,17 +271,17 @@ def _warn_redundant_cd(config: OssatureConfig) -> None:
     output_dir = config.output.dir
     prefix = f"cd {output_dir}"
     fields = {"setup": config.build.setup, "verify": config.build.verify, "test": config.build.test}
-    for field_name, command in fields.items():
-        if not command:
-            continue
-        stripped = command.lstrip()
-        if not stripped.startswith(prefix):
-            continue
-        rest = stripped[len(prefix) :]
-        if rest == "" or rest[0] in (" ", "\t", ";", "&"):
-            warnings.warn(
-                f"[build] {field_name} contains 'cd {output_dir}' — "
-                f"this is unnecessary. All build commands already run "
-                f"inside the output directory ({output_dir!r}).",
-                stacklevel=2,
-            )
+    for field_name, commands in fields.items():
+        for command in commands:
+            stripped = command.lstrip()
+            if not stripped.startswith(prefix):
+                continue
+            rest = stripped[len(prefix) :]
+            if rest == "" or rest[0] in (" ", "\t", ";", "&"):
+                warnings.warn(
+                    f"[build] {field_name} contains 'cd {output_dir}' — "
+                    f"this is unnecessary. All build commands already run "
+                    f"inside the output directory ({output_dir!r}).",
+                    stacklevel=2,
+                )
+                break

--- a/src/ossature/models/plan.py
+++ b/src/ossature/models/plan.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class TaskStatus(Enum):
@@ -12,6 +12,22 @@ class TaskStatus(Enum):
     MANUAL = "manual"
 
 
+def _coerce_verify(value: Any) -> list[str]:
+    """Normalize a `verify` field to a list of command strings.
+
+    Accepts either a single shell-command string (legacy form) or a list
+    of strings (preferred form). An empty string becomes an empty list so
+    "no verify" is represented uniformly.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    raise TypeError(f"verify must be a string or a list of strings, got {type(value).__name__}")
+
+
 class PlannerTask(BaseModel):
     kind: Literal["task"] = "task"
     title: str
@@ -20,8 +36,13 @@ class PlannerTask(BaseModel):
     depends_on: list[int]
     spec_refs: list[str]
     arch_refs: list[str]
-    verify: str
+    verify: list[str]
     context_files: list[str] = []
+
+    @field_validator("verify", mode="before")
+    @classmethod
+    def _normalize_verify(cls, value: Any) -> list[str]:
+        return _coerce_verify(value)
 
 
 class PreservedTaskRef(BaseModel):
@@ -46,11 +67,16 @@ class PlanTask(BaseModel):
     spec_refs: list[str]
     arch_refs: list[str]
     status: TaskStatus = TaskStatus.PENDING
-    verify: str
+    verify: list[str]
     inject_files: list[str] = []
     cross_spec_interfaces: list[str] = []
     context_files: list[str] = []
     notes: str = ""
+
+    @field_validator("verify", mode="before")
+    @classmethod
+    def _normalize_verify(cls, value: Any) -> list[str]:
+        return _coerce_verify(value)
 
 
 class PlanMeta(BaseModel):

--- a/src/ossature/templates/files/config.template
+++ b/src/ossature/templates/files/config.template
@@ -20,9 +20,9 @@ coverage_threshold = 80.0
 # max_fix_cycles = 3                                   # audit → fix → re-audit cycles per spec
 
 [build]
-# setup = "uv init && uv sync"                         # Run before first task
-# verify = "uv run python -m py_compile"               # Override default verify
-# test = "uv run pytest"                               # Override default test
+# setup = ["uv init", "uv sync"]                       # Run before first task (list of commands)
+# verify = ["uv run python -m py_compile"]             # Override default verify (list of commands)
+# test = ["uv run pytest"]                             # Override default test (list of commands)
 # max_fix_attempts = 3                                 # verify-fail → fix → re-verify per task
 # max_inline_lines = 200                               # files above this aren't inlined in fix prompts
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,16 +71,23 @@ def make_config(
     root: Path,
     language: str = "python",
     output_dir: str = "output",
-    setup: str | None = None,
-    verify: str | None = None,
-    test: str | None = None,
+    setup: str | list[str] | None = None,
+    verify: str | list[str] | None = None,
+    test: str | list[str] | None = None,
 ) -> OssatureConfig:
+    def _to_list(value: str | list[str] | None) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value] if value else []
+        return list(value)
+
     return OssatureConfig(
         name="test",
         version="0.0.1",
         root=root,
         output=OutputConfig(dir=output_dir, language=language),
-        build=BuildConfig(setup=setup, verify=verify, test=test),
+        build=BuildConfig(setup=_to_list(setup), verify=_to_list(verify), test=_to_list(test)),
     )
 
 
@@ -101,7 +108,7 @@ def make_task(
     outputs: list[str] | None = None,
     depends_on: list[str] | None = None,
     status: TaskStatus = TaskStatus.PENDING,
-    verify: str = "",
+    verify: str | list[str] = "",
 ) -> PlanTask:
     return PlanTask(
         id=id,

--- a/tests/unit/test_build_setup.py
+++ b/tests/unit/test_build_setup.py
@@ -5,12 +5,18 @@ from unittest.mock import MagicMock, patch
 from conftest import make_config, make_plan, make_task
 
 from ossature.build.builder import (
+    DefaultBuildBackend,
     _command_groups_from_plan,
     _extract_executables_for_group,
+    _format_verify_for_display,
+    _print_task_header,
+    _prompt_after_failure,
     _split_tokens,
     check_tool_availability,
     run_setup,
+    run_verify,
 )
+from ossature.models.plan import PlanTask
 
 
 class TestRunSetup:
@@ -89,6 +95,209 @@ class TestRunSetup:
         with patch("ossature.build.builder.subprocess.run", side_effect=results) as mock_run:
             assert run_setup(config, console) is False
             assert mock_run.call_count == 2
+
+
+class TestRunVerify:
+    def test_no_commands_returns_success(self, temp_dir: Path):
+        assert run_verify([], temp_dir) == (True, "")
+
+    def test_single_command_success_returns_stripped_stdout(self, temp_dir: Path):
+        ok, output = run_verify(["echo hello"], temp_dir)
+        assert ok is True
+        assert output == "hello"
+
+    def test_single_command_success_no_output(self, temp_dir: Path):
+        ok, output = run_verify(["true"], temp_dir)
+        assert ok is True
+        assert output == ""
+
+    def test_single_command_failure_returns_output(self, temp_dir: Path):
+        ok, output = run_verify(["sh -c 'echo boom >&2; exit 1'"], temp_dir)
+        assert ok is False
+        assert "boom" in output
+
+    def test_multi_step_success_includes_headers(self, temp_dir: Path):
+        ok, output = run_verify(["echo first", "echo second"], temp_dir)
+        assert ok is True
+        assert "$ echo first" in output
+        assert "first" in output
+        assert "$ echo second" in output
+        assert "second" in output
+
+    def test_multi_step_includes_header_for_silent_step(self, temp_dir: Path):
+        ok, output = run_verify(["true", "echo done"], temp_dir)
+        assert ok is True
+        # First command produces no output but its header still appears
+        assert "$ true" in output
+        assert "$ echo done" in output
+        assert "done" in output
+
+    def test_multi_step_fail_fast_stops_on_first_failure(self, temp_dir: Path):
+        ok, output = run_verify(["echo step-1", "false", "echo never-runs"], temp_dir)
+        assert ok is False
+        assert "step-1" in output
+        assert "never-runs" not in output
+
+    def test_combines_stdout_and_stderr(self, temp_dir: Path):
+        ok, output = run_verify(["sh -c 'echo out; echo err >&2'"], temp_dir)
+        assert ok is True
+        assert "out" in output
+        assert "err" in output
+
+    def test_runs_in_specified_cwd(self, temp_dir: Path):
+        ok, output = run_verify(["pwd"], temp_dir)
+        assert ok is True
+        assert str(temp_dir.resolve()) in str(Path(output).resolve())
+
+    def test_timeout_returns_failure(self, temp_dir: Path):
+        with patch(
+            "ossature.build.builder.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("sleep", 120),
+        ):
+            ok, output = run_verify(["sleep 999"], temp_dir)
+            assert ok is False
+            assert "timed out" in output
+
+
+class TestDefaultBuildBackendVerify:
+    def test_delegates_to_run_verify(self, temp_dir: Path):
+        config = make_config(temp_dir, language="python")
+        backend = DefaultBuildBackend(config)
+        ok, output = backend.verify(["echo hello"], temp_dir)
+        assert ok is True
+        assert output == "hello"
+
+    def test_no_commands_returns_success(self, temp_dir: Path):
+        config = make_config(temp_dir, language="python")
+        backend = DefaultBuildBackend(config)
+        assert backend.verify([], temp_dir) == (True, "")
+
+
+class TestDefaultBuildBackendGenerate:
+    def test_returns_agent_output(self, temp_dir: Path):
+        config = make_config(temp_dir, language="python")
+        backend = DefaultBuildBackend(config)
+
+        fake_result = MagicMock()
+        fake_result.output = "generated source"
+
+        with (
+            patch("ossature.build.builder._create_impl_agent") as mock_create,
+            patch("ossature.build.builder._run_with_retry", return_value=fake_result),
+        ):
+            output = backend.generate(
+                "build prompt", MagicMock(), MagicMock(), MagicMock(), "test-model"
+            )
+            assert output == "generated source"
+            mock_create.assert_called_once_with(config)
+
+
+class TestDefaultBuildBackendFix:
+    def test_returns_agent_output(self, temp_dir: Path):
+        config = make_config(temp_dir, language="python")
+        backend = DefaultBuildBackend(config)
+
+        fake_result = MagicMock()
+        fake_result.output = "patched source"
+
+        with (
+            patch("ossature.build.builder._create_fix_agent") as mock_create,
+            patch("ossature.build.builder._run_with_retry", return_value=fake_result),
+        ):
+            output = backend.fix("fix prompt", MagicMock(), MagicMock(), MagicMock(), "test-model")
+            assert output == "patched source"
+            mock_create.assert_called_once_with(config)
+
+
+class TestPrintTaskHeader:
+    def _task(self, **overrides) -> PlanTask:
+        defaults = {
+            "id": "042",
+            "spec": "CORE",
+            "title": "Build the thing",
+            "description": "Construct widgets",
+            "outputs": ["src/widget.py", "src/lib.py"],
+            "depends_on": [],
+            "spec_refs": [],
+            "arch_refs": [],
+            "verify": [],
+        }
+        defaults.update(overrides)
+        return PlanTask(**defaults)
+
+    def test_silent_when_not_verbose(self):
+        console = MagicMock()
+        _print_task_header(console, self._task(), total=99, verbose=False)
+        console.print.assert_not_called()
+
+    def test_verbose_emits_header_description_and_outputs(self):
+        console = MagicMock()
+        _print_task_header(console, self._task(), total=99, verbose=True)
+
+        printed = " ".join(str(c.args[0]) if c.args else "" for c in console.print.call_args_list)
+        assert "042/099" in printed
+        assert "Build the thing" in printed
+        assert "Construct widgets" in printed
+        assert "src/widget.py" in printed
+        assert "src/lib.py" in printed
+
+    def test_verbose_omits_outputs_line_when_empty(self):
+        console = MagicMock()
+        _print_task_header(console, self._task(outputs=[]), total=10, verbose=True)
+
+        printed = " ".join(str(c.args[0]) if c.args else "" for c in console.print.call_args_list)
+        # The outputs line is the only one that uses the `->` arrow
+        assert "->" not in printed
+
+
+class TestPromptAfterFailure:
+    def _task(self) -> PlanTask:
+        return PlanTask(
+            id="001",
+            spec="CORE",
+            title="t",
+            description="d",
+            outputs=[],
+            depends_on=[],
+            spec_refs=[],
+            arch_refs=[],
+            verify=[],
+        )
+
+    def test_retry_response(self):
+        with patch("builtins.input", return_value="r"):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "retry"
+
+    def test_skip_response(self):
+        with patch("builtins.input", return_value="s"):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "skip"
+
+    def test_unknown_response_quits(self):
+        with patch("builtins.input", return_value=""):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "quit"
+
+    def test_response_is_case_insensitive(self):
+        with patch("builtins.input", return_value="R"):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "retry"
+
+    def test_eof_quits(self):
+        with patch("builtins.input", side_effect=EOFError):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "quit"
+
+    def test_keyboard_interrupt_quits(self):
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            assert _prompt_after_failure(MagicMock(), self._task()) == "quit"
+
+
+class TestFormatVerifyForDisplay:
+    def test_empty_list_returns_empty_string(self):
+        assert _format_verify_for_display([]) == ""
+
+    def test_single_command_returned_as_is(self):
+        assert _format_verify_for_display(["cargo check"]) == "cargo check"
+
+    def test_multiple_commands_joined_with_and(self):
+        assert _format_verify_for_display(["make", "./app --help"]) == "make && ./app --help"
 
 
 class TestCommandGroupsFromPlan:

--- a/tests/unit/test_build_setup.py
+++ b/tests/unit/test_build_setup.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, patch
 from conftest import make_config, make_plan, make_task
 
 from ossature.build.builder import (
-    _extract_commands_from_plan,
-    _extract_executables,
+    _command_groups_from_plan,
+    _extract_executables_for_group,
+    _split_tokens,
     check_tool_availability,
     run_setup,
 )
@@ -58,65 +59,157 @@ class TestRunSetup:
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs["cwd"] == str(output_dir)
 
-
-class TestExtractCommands:
-    def test_collects_from_plan_and_config(self, temp_dir: Path):
+    def test_setup_list_runs_each_step(self, temp_dir: Path):
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
         config = make_config(
-            temp_dir, language="rust", setup="cargo init", verify="cargo check", test="cargo test"
+            temp_dir,
+            language="rust",
+            setup=["echo step-1", "echo step-2", "echo step-3"],
+        )
+        console = MagicMock()
+
+        with patch("ossature.build.builder.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args="echo", returncode=0, stdout="", stderr=""
+            )
+            assert run_setup(config, console) is True
+            assert mock_run.call_count == 3
+
+    def test_setup_list_stops_at_first_failure(self, temp_dir: Path):
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        config = make_config(temp_dir, language="rust", setup=["echo first", "false", "echo never"])
+        console = MagicMock()
+
+        results = [
+            subprocess.CompletedProcess(args="echo first", returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args="false", returncode=1, stdout="", stderr=""),
+        ]
+        with patch("ossature.build.builder.subprocess.run", side_effect=results) as mock_run:
+            assert run_setup(config, console) is False
+            assert mock_run.call_count == 2
+
+
+class TestCommandGroupsFromPlan:
+    def test_collects_per_scope_groups(self, temp_dir: Path):
+        config = make_config(
+            temp_dir,
+            language="rust",
+            setup="cargo init",
+            verify="cargo check",
+            test="cargo test",
         )
         plan = make_plan(
             [
-                make_task("001", "TEST", verify="cargo check"),
-                make_task("002", "TEST", verify="cargo test"),
+                make_task("001", "TEST", verify=["cargo check", "cargo test"]),
+                make_task("002", "TEST", verify="cargo build"),
             ]
         )
-        commands = _extract_commands_from_plan(plan, config)
-        assert "cargo init" in commands
-        assert "cargo check" in commands
-        assert "cargo test" in commands
+        groups = _command_groups_from_plan(plan, config)
+        # 3 build-config groups + 2 task verify groups
+        assert ["cargo init"] in groups
+        assert ["cargo check"] in groups
+        assert ["cargo test"] in groups
+        assert ["cargo check", "cargo test"] in groups
+        assert ["cargo build"] in groups
+        assert len(groups) == 5
 
     def test_empty_plan_and_config(self, temp_dir: Path):
         config = make_config(temp_dir, language="rust")
         plan = make_plan([])
-        assert _extract_commands_from_plan(plan, config) == set()
+        assert _command_groups_from_plan(plan, config) == []
 
 
-class TestExtractExecutables:
+class TestSplitTokens:
+    def test_simple(self):
+        assert _split_tokens("cargo check") == ["cargo", "check"]
+
+    def test_quoted(self):
+        assert _split_tokens('echo "hello world"') == ["echo", "hello world"]
+
+    def test_malformed_quoting_falls_back(self):
+        assert _split_tokens("echo 'unbalanced") == ["echo", "'unbalanced"]
+
+
+class TestExtractExecutablesForGroup:
     def test_simple_command(self):
-        assert _extract_executables({"cargo check"}) == {"cargo"}
-
-    def test_chained_commands(self):
-        result = _extract_executables({"mkdir -p build && cmake .."})
-        assert "mkdir" in result
-        assert "cmake" in result
-
-    def test_piped_commands(self):
-        result = _extract_executables({"make 2>&1 | head"})
-        assert "make" in result
-        assert "head" in result
+        assert set(_extract_executables_for_group(["cargo check"])) == {"cargo"}
 
     def test_skips_builtins(self):
-        result = _extract_executables({"cd build && cmake .."})
-        assert "cd" not in result
-        assert "cmake" in result
+        exes = _extract_executables_for_group(["cd build && cmake .."])
+        assert "cd" not in exes
+        assert "cmake" in exes
 
     def test_env_var_prefix(self):
-        result = _extract_executables({"CC=gcc make"})
-        assert "make" in result
-        assert "CC=gcc" not in result
+        assert set(_extract_executables_for_group(["CC=gcc make"])) == {"make"}
 
-    def test_semicolons(self):
-        result = _extract_executables({"cargo check; cargo test"})
-        assert "cargo" in result
+    def test_chained_in_single_string(self):
+        assert set(_extract_executables_for_group(["mkdir -p build && cmake .."])) == {
+            "mkdir",
+            "cmake",
+        }
 
-    def test_ignores_tokens_inside_quoted_strings(self):
-        cmd = (
-            "python -m mypy src/spenny/core.py --check-unused-ignore "
-            '&& python -c "from spenny.core import add_expense; '
-            "print('Core module imported successfully')\""
+    def test_compile_then_run_chained_in_single_string(self):
+        # Bug repro: /tmp/yep_test contains a slash so the shell never
+        # consults PATH — it's invoked by direct file path.
+        exes = _extract_executables_for_group(
+            ["gcc -Wall -o /tmp/yep_test yep.c && /tmp/yep_test --help > /dev/null"]
         )
-        result = _extract_executables({cmd})
-        assert result == {"python"}
+        assert set(exes) == {"gcc"}
+
+    def test_compile_then_run_as_list(self):
+        exes = _extract_executables_for_group(
+            ["gcc -o /tmp/yep_test yep.c", "/tmp/yep_test --help"]
+        )
+        assert set(exes) == {"gcc"}
+
+    def test_other_missing_tool_still_caught(self):
+        # `other_missing_tool` is bare (no slash) → still flagged.
+        exes = _extract_executables_for_group(["gcc -o /tmp/a a.c && /tmp/a && other_missing_tool"])
+        assert set(exes) == {"gcc", "other_missing_tool"}
+
+    def test_path_based_invocation_never_flagged(self):
+        # Generic: any token containing `/` bypasses PATH and is treated
+        # as a project artifact — works for any language/build system.
+        assert set(_extract_executables_for_group(["./yep --help"])) == set()
+        assert set(_extract_executables_for_group(["target/release/myapp"])) == set()
+        assert set(_extract_executables_for_group(["zig-out/bin/x --version"])) == set()
+        assert set(_extract_executables_for_group(["build/Release/foo"])) == set()
+        assert set(_extract_executables_for_group(["node_modules/.bin/eslint"])) == set()
+        assert set(_extract_executables_for_group(["/opt/bin/foo --version"])) == set()
+
+    def test_make_then_run_compiled_binary(self):
+        # `make` produces ./yep via Makefile; ./yep contains a slash so we
+        # never need to know that `make` is what produced it.
+        exes = _extract_executables_for_group(
+            [
+                "make clean",
+                "make CFLAGS='-std=c99 -Wall -Wextra -pedantic'",
+                "./yep --help > /tmp/yep_help.txt",
+                "grep -q -- '--help' /tmp/yep_help.txt",
+                "./yep --version > /tmp/yep_version.txt",
+            ]
+        )
+        assert set(exes) == {"make", "grep"}
+
+    def test_cargo_then_run_release_binary(self):
+        exes = _extract_executables_for_group(
+            ["cargo build --release", "target/release/myapp --version"]
+        )
+        assert set(exes) == {"cargo"}
+
+    def test_zig_build_then_run(self):
+        exes = _extract_executables_for_group(["zig build", "zig-out/bin/myapp --help"])
+        assert set(exes) == {"zig"}
+
+    def test_go_build_then_run(self):
+        exes = _extract_executables_for_group(["go build -o bin/app ./...", "bin/app --help"])
+        assert set(exes) == {"go"}
+
+    def test_npm_then_run_local_bin(self):
+        exes = _extract_executables_for_group(["npm install", "node_modules/.bin/jest"])
+        assert set(exes) == {"npm"}
 
 
 class TestCheckToolAvailability:
@@ -152,3 +245,106 @@ class TestCheckToolAvailability:
         console = MagicMock()
         result = check_tool_availability(plan, config, console)
         assert result is False
+
+    @patch("ossature.build.builder.shutil.which")
+    def test_compile_then_run_list_form_does_not_flag_produced_binary(
+        self, mock_which, temp_dir: Path
+    ):
+        # Pretend gcc is on PATH, but /tmp/yep_test obviously isn't
+        mock_which.side_effect = lambda exe: "/usr/bin/gcc" if exe == "gcc" else None
+        config = make_config(temp_dir, language="rust")
+        plan = make_plan(
+            [
+                make_task(
+                    "001",
+                    "YEP",
+                    verify=[
+                        "gcc -Wall -Wextra -std=c99 -o /tmp/yep_test yep.c",
+                        "/tmp/yep_test --help > /dev/null",
+                    ],
+                )
+            ]
+        )
+        console = MagicMock()
+        assert check_tool_availability(plan, config, console) is True
+
+    @patch("ossature.build.builder.shutil.which")
+    def test_compile_then_run_chained_string_form_does_not_flag_produced_binary(
+        self, mock_which, temp_dir: Path
+    ):
+        # Same scenario but verify is one chained shell string (back-compat).
+        mock_which.side_effect = lambda exe: "/usr/bin/gcc" if exe == "gcc" else None
+        config = make_config(temp_dir, language="rust")
+        plan = make_plan(
+            [
+                make_task(
+                    "001",
+                    "YEP",
+                    verify=(
+                        "gcc -Wall -Wextra -std=c99 -o /tmp/yep_test yep.c "
+                        "&& /tmp/yep_test --help > /dev/null"
+                    ),
+                )
+            ]
+        )
+        console = MagicMock()
+        assert check_tool_availability(plan, config, console) is True
+
+    @patch("ossature.build.builder.shutil.which")
+    def test_bare_name_without_slash_is_flagged(self, mock_which, temp_dir: Path):
+        # `myprog` (no slash) is treated as a PATH lookup. Without `./`,
+        # the shell wouldn't actually find it in cwd either, so flagging
+        # is the right behavior — and tells the user to fix their verify
+        # command to use a path.
+        def _which(exe: str) -> str | None:
+            return "/usr/bin/gcc" if exe == "gcc" else None
+
+        mock_which.side_effect = _which
+        config = make_config(temp_dir, language="c")
+        plan = make_plan(
+            [
+                make_task("001", "A", verify=["gcc -o myprog x.c", "myprog --help"]),
+            ]
+        )
+        console = MagicMock()
+        assert check_tool_availability(plan, config, console) is False
+
+    @patch("ossature.build.builder.shutil.which")
+    def test_yep_project_real_world_plan(self, mock_which, temp_dir: Path):
+        # Mirrors /Users/beshr/src/code/yep/.ossature/plan.toml — the
+        # original failing case. `make` produces ./yep via the Makefile;
+        # ./yep is invoked by direct path and must not be flagged.
+        def _which(exe: str) -> str | None:
+            if exe in {"make", "grep", "sh"}:
+                return f"/usr/bin/{exe}"
+            return None
+
+        mock_which.side_effect = _which
+        config = make_config(temp_dir, language="c")
+        plan = make_plan(
+            [
+                make_task("001", "YEP", verify=["make -n yep", "make -n clean"]),
+                make_task(
+                    "002",
+                    "YEP",
+                    verify=[
+                        "make clean",
+                        "make CFLAGS='-std=c99 -Wall -Wextra -pedantic'",
+                        "./yep --help > /tmp/yep_help.txt",
+                        "grep -q -- '--help' /tmp/yep_help.txt",
+                        "./yep --version > /tmp/yep_version.txt",
+                    ],
+                ),
+                make_task(
+                    "003",
+                    "YEP",
+                    verify=[
+                        "make clean",
+                        "make CFLAGS='-std=c99 -Wall -Wextra -pedantic'",
+                        "sh tests/test_yep.sh",
+                    ],
+                ),
+            ]
+        )
+        console = MagicMock()
+        assert check_tool_availability(plan, config, console) is True

--- a/tests/unit/test_build_task.py
+++ b/tests/unit/test_build_task.py
@@ -12,7 +12,7 @@ from ossature.models.plan import PlanTask
 from ossature.shared.llm import UsageTracker
 
 
-def _make_task(verify: str = "cargo test") -> PlanTask:
+def _make_task(verify: str | list[str] = "cargo test") -> PlanTask:
     return PlanTask(
         id="010",
         spec="CORE",
@@ -53,7 +53,7 @@ class FakeBackend:
         self._fix_idx = 0
         self.generate_calls: list[str] = []
         self.fix_calls: list[str] = []
-        self.verify_calls: list[str] = []
+        self.verify_calls: list[list[str]] = []
 
     def generate(
         self,
@@ -87,8 +87,8 @@ class FakeBackend:
         ctx.created_files.append(f"fix-file-{idx}.rs")
         return "fix applied"
 
-    def verify(self, command: str, cwd: Path) -> tuple[bool, str]:
-        self.verify_calls.append(command)
+    def verify(self, commands: list[str], cwd: Path) -> tuple[bool, str]:
+        self.verify_calls.append(commands)
         idx = self._verify_idx
         self._verify_idx += 1
         if idx < len(self._verify_results):
@@ -99,7 +99,7 @@ class FakeBackend:
 def _run(
     tmp_path: Path,
     backend: FakeBackend,
-    verify: str = "cargo test",
+    verify: str | list[str] = "cargo test",
 ):
     task = _make_task(verify=verify)
     config = _make_config(tmp_path)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -51,9 +51,9 @@ class TestConfigLoader:
 
     def test_build_config_defaults(self, sample_config: OssatureConfig):
         assert sample_config.build.max_fix_attempts == 3
-        assert sample_config.build.setup is None
-        assert sample_config.build.verify is None
-        assert sample_config.build.test is None
+        assert sample_config.build.setup == []
+        assert sample_config.build.verify == []
+        assert sample_config.build.test == []
 
     def test_load_config_with_build_section(self, temp_dir: Path):
         config_content = """
@@ -76,10 +76,32 @@ model = "anthropic:claude-sonnet-4-6"
 """
         (temp_dir / "ossature.toml").write_text(config_content)
         config = load_config(temp_dir / "ossature.toml")
-        assert config.build.setup == "cargo init"
-        assert config.build.verify == "cargo check"
-        assert config.build.test == "cargo test"
+        # Strings are normalized to single-element lists.
+        assert config.build.setup == ["cargo init"]
+        assert config.build.verify == ["cargo check"]
+        assert config.build.test == ["cargo test"]
         assert config.build.max_fix_attempts == 5
+
+    def test_load_config_with_build_section_list_form(self, temp_dir: Path):
+        config_content = """
+[project]
+name = "test-project"
+version = "0.0.1"
+
+[output]
+dir = "output"
+language = "c"
+
+[build]
+verify = ["gcc -o /tmp/yep yep.c", "/tmp/yep --help"]
+
+[llm]
+model = "anthropic:claude-sonnet-4-6"
+"""
+        (temp_dir / "ossature.toml").write_text(config_content)
+        config = load_config(temp_dir / "ossature.toml")
+        assert config.build.verify == ["gcc -o /tmp/yep yep.c", "/tmp/yep --help"]
+        assert config.build.setup == []
 
     def test_llm_config_defaults(self, sample_config: OssatureConfig):
         assert sample_config.llm.model == DEFAULT_MODEL

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 
 import pytest
@@ -262,3 +263,66 @@ audit = "anthropic:claude-opus-4-6"
         content = config_path.read_text()
         assert "[llm]" in content
         assert "model =" in content
+
+    def test_build_command_invalid_type_raises(self, temp_dir: Path):
+        config_content = """
+[project]
+name = "test-project"
+version = "0.0.1"
+
+[output]
+dir = "output"
+language = "python"
+
+[build]
+setup = 42
+
+[llm]
+model = "anthropic:claude-sonnet-4-6"
+"""
+        (temp_dir / "ossature.toml").write_text(config_content)
+        with pytest.raises(ConfigError, match="build command must be a string or a list"):
+            load_config(temp_dir / "ossature.toml")
+
+    def test_warns_when_command_starts_with_cd_output_dir(self, temp_dir: Path):
+        config_content = """
+[project]
+name = "test-project"
+version = "0.0.1"
+
+[output]
+dir = "output"
+language = "python"
+
+[build]
+verify = ["cd output && pytest"]
+
+[llm]
+model = "anthropic:claude-sonnet-4-6"
+"""
+        (temp_dir / "ossature.toml").write_text(config_content)
+        with pytest.warns(UserWarning, match="cd output.*unnecessary"):
+            load_config(temp_dir / "ossature.toml")
+
+    def test_does_not_warn_when_cd_targets_subdirectory(self, temp_dir: Path):
+        # `cd output_subdir` should not match `cd output`. The prefix check
+        # only fires when the next character is a separator.
+        config_content = """
+[project]
+name = "test-project"
+version = "0.0.1"
+
+[output]
+dir = "output"
+language = "python"
+
+[build]
+verify = ["cd output_subdir && pytest"]
+
+[llm]
+model = "anthropic:claude-sonnet-4-6"
+"""
+        (temp_dir / "ossature.toml").write_text(config_content)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning would fail this test
+            load_config(temp_dir / "ossature.toml")

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -1451,7 +1451,7 @@ class TestFormatPreviousTasks:
                 spec_refs=["overview", "Requirements > Token Format"],
                 arch_refs=["Components > TokenManager"],
                 status=TaskStatus.DONE,
-                verify="cargo check",
+                verify=["cargo check"],
                 context_files=["ref.txt"],
             ),
         ]
@@ -1479,7 +1479,7 @@ class TestFormatPreviousTasks:
                 spec_refs=[],
                 arch_refs=[],
                 status=TaskStatus.DONE,
-                verify="x",
+                verify=["x"],
             ),
         ]
 
@@ -1489,3 +1489,69 @@ class TestFormatPreviousTasks:
         assert "spec_refs" not in formatted
         assert "arch_refs" not in formatted
         assert "context_files" not in formatted
+
+    def test_multi_step_verify_rendered_as_list(self):
+        """A multi-step verify is rendered as the list itself, not a single string."""
+        tasks = [
+            PlanTask(
+                id="001",
+                spec="APP",
+                title="t",
+                description="d",
+                outputs=[],
+                depends_on=[],
+                spec_refs=[],
+                arch_refs=[],
+                status=TaskStatus.DONE,
+                verify=["make", "./app --help"],
+            ),
+        ]
+
+        formatted = _format_previous_tasks(tasks)
+
+        # Both commands should appear, and the list repr keeps them together
+        assert "make" in formatted
+        assert "./app --help" in formatted
+        assert "['make', './app --help']" in formatted
+
+
+class TestVerifyNormalization:
+    """The verify field accepts None, str, or list[str]; anything else raises."""
+
+    def _kwargs(self) -> dict:
+        return {
+            "id": "001",
+            "spec": "X",
+            "title": "t",
+            "description": "d",
+            "outputs": [],
+            "depends_on": [],
+            "spec_refs": [],
+            "arch_refs": [],
+        }
+
+    def _planner_kwargs(self) -> dict:
+        return {
+            "title": "t",
+            "description": "d",
+            "outputs": [],
+            "depends_on": [],
+            "spec_refs": [],
+            "arch_refs": [],
+        }
+
+    def test_none_becomes_empty_list_on_plan_task(self):
+        task = PlanTask(verify=None, **self._kwargs())
+        assert task.verify == []
+
+    def test_none_becomes_empty_list_on_planner_task(self):
+        task = PlannerTask(verify=None, **self._planner_kwargs())
+        assert task.verify == []
+
+    def test_invalid_type_raises_on_plan_task(self):
+        with pytest.raises(Exception, match="verify must be a string or a list"):
+            PlanTask(verify=42, **self._kwargs())
+
+    def test_invalid_type_raises_on_planner_task(self):
+        with pytest.raises(Exception, match="verify must be a string or a list"):
+            PlannerTask(verify={"bad": "type"}, **self._planner_kwargs())

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -1313,7 +1313,7 @@ class TestResolvePreservedRefs:
         assert task.title == "Scaffold"
         assert task.description == "Create scaffold"
         assert task.outputs == ["src/mod.rs"]
-        assert task.verify == "cargo check"
+        assert task.verify == ["cargo check"]
         assert task.context_files == ["ref.txt"]
         # Spec prefix stripped
         assert task.spec_refs == ["overview"]

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -42,7 +42,7 @@ class TestResolveSandboxed:
         self, tmp_path: Path, quiet_console: Console
     ) -> None:
         with pytest.raises(ModelRetry, match="Access denied"):
-            _resolve_sandboxed(tmp_path, "/tmp/evil", quiet_console)  # noqa: S108
+            _resolve_sandboxed(tmp_path, "/tmp/evil", quiet_console)
 
     def test_allows_current_dir(self, tmp_path: Path, quiet_console: Console) -> None:
         result = _resolve_sandboxed(tmp_path, ".", quiet_console)


### PR DESCRIPTION
**What does this change?**

Resolves #49.

The build pre-flight tool check flagged binaries produced by earlier steps in the same `verify` pipeline as missing PATH dependencies.

With this PR, path-based tokens like `./app`, `target/release/foo`, `/tmp/x`, etc.) are treated as project artifacts and skipped, matching how the shell resolves them.

Additionally, `verify`, `setup`, and `test` fields are now `list[str]` across `PlannerTask`, `PlanTask`, and `BuildConfig`. Each step runs in its own shell, fail-fast, with appropriate output. Single string commands are still accepted, so existing `plan.toml` and `ossature.toml` files keep working.

The planner prompt was updated to output verify as a list, reference produced binaries by path, scope each step to the current task's outputs, and skip invoking the build in scaffold-only tasks.

Side thing: this PR also enhances the integration with codecov to send test analysis and setup flags/components.

**How was it tested?**

- Expanded unit coverage for path-based invocations across common build systems (cargo, zig, go, make, npm) and a replay of the failing plan from #49.
- All tests pass
- Verified end-to-end against example projects

