### PR TITLE
feat: add source field for verbatim copy tasks

### DIFF
--- a/src/ossature/audit/planner.py
+++ b/src/ossature/audit/planner.py
@@ -1,5 +1,6 @@
 import difflib
 import shutil
+import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -102,6 +103,8 @@ def _format_previous_tasks(tasks: list[PlanTask]) -> str:
             lines.append(f"- verify: {task.verify}")
         if task.context_files:
             lines.append(f"- context_files: {task.context_files}")
+        if task.source:
+            lines.append(f"- source: {task.source}")
         lines.append("")
     return "\n".join(lines)
 
@@ -149,6 +152,7 @@ def _resolve_preserved_refs(
                 arch_refs=list(old.arch_refs),
                 verify=old.verify,
                 context_files=list(old.context_files),
+                source=list(old.source),
             )
         )
 
@@ -224,7 +228,12 @@ def generate_spec_plan(
             "The build system will include text files in the prompt and provide tools "
             "for the implementer to copy binary assets to the appropriate location "
             "within the output directory (e.g. an `assets/` or `sounds/` subdirectory, "
-            "wherever fits the project structure)."
+            "wherever fits the project structure).\n\n"
+            "For files that should ship verbatim with no transformation (binary assets, "
+            "fixtures, reference data), prefer emitting a copy task: set "
+            '`source = ["context://<path-or-glob>"]` and `verify = []`. The build '
+            "system will copy the matched files directly without calling the LLM. "
+            "See the `source` field in the output format."
         )
 
     user_prompt = "\n".join(sections)
@@ -312,6 +321,7 @@ def merge_into_global_plan(
                     inject_files=inject_files,
                     cross_spec_interfaces=cross_spec_interfaces,
                     context_files=list(planner_task.context_files),
+                    source=list(planner_task.source),
                 )
                 all_tasks.append(task)
             spec_local_to_global[spec_id] = local_to_global
@@ -533,6 +543,7 @@ def incremental_merge_plan(
                         inject_files=inject_files,
                         cross_spec_interfaces=cross_spec_interfaces,
                         context_files=list(planner_task.context_files),
+                        source=list(planner_task.source),
                         notes=notes,
                     )
                     all_tasks.append(task)
@@ -581,6 +592,7 @@ def incremental_merge_plan(
                         inject_files=new_inject,
                         cross_spec_interfaces=task.cross_spec_interfaces,
                         context_files=list(task.context_files),
+                        source=list(task.source),
                         notes=task.notes,
                     )
                     all_tasks.append(new_task)
@@ -751,6 +763,8 @@ def write_plan(plan: Plan, filepath: Path) -> None:
             task_dict["cross_spec_interfaces"] = task.cross_spec_interfaces
         if task.context_files:
             task_dict["context_files"] = task.context_files
+        if task.source:
+            task_dict["source"] = [f"context://{s}" for s in task.source]
         if task.notes:
             task_dict["notes"] = task.notes
         data["task"].append(task_dict)
@@ -802,10 +816,20 @@ def load_plan(filepath: Path) -> Plan | None:
             inject_files=t.get("inject_files", []),
             cross_spec_interfaces=t.get("cross_spec_interfaces", []),
             context_files=t.get("context_files", []),
+            source=t.get("source", []),
             notes=t.get("notes", ""),
         )
         for t in data.get("task", [])
     ]
+
+    for task in tasks:
+        if task.source and task.verify:
+            warnings.warn(
+                f"plan.toml task {task.id}: `verify` is ignored for copy tasks "
+                f"(source is set). Set verify = [] to silence this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     return Plan(meta=meta, tasks=tasks)
 
@@ -834,6 +858,8 @@ def write_task_definitions(plan: Plan, tasks_dir: Path) -> None:
             task_data["cross_spec_interfaces"] = task.cross_spec_interfaces
         if task.context_files:
             task_data["context_files"] = task.context_files
+        if task.source:
+            task_data["source"] = [f"context://{s}" for s in task.source]
         if task.notes:
             task_data["notes"] = task.notes
 

--- a/src/ossature/audit/prompts.py
+++ b/src/ossature/audit/prompts.py
@@ -165,6 +165,24 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     "Your first task should assume the setup command has already run.\n\n"
     "If audit findings are provided, account for them in your planning — "
     "avoid generating tasks that would hit known spec issues.\n\n"
+    "## Verbatim copy tasks (source)\n"
+    "Some outputs are not generated — they are pre-existing assets that ship "
+    "as-is (binary assets, fixtures, reference data files, prompt templates). "
+    "For these, emit a copy task: set the `source` field to one or more "
+    "`context://<path-or-glob>` patterns and leave `verify` empty. The build "
+    "system copies the matched file(s) from the context directory directly, "
+    "without invoking the LLM. Use this when:\n"
+    "- The context file is an opaque/binary asset (.mp3, .wav, .png, .jpg, "
+    ".gif, .ttf, .otf, .mp4, .webm, .bin, .pdf, fonts, fixtures).\n"
+    "- The output is byte-identical to the context file with no transformation.\n"
+    "- The task title naturally reads 'Copy X', 'Bundle X', 'Ship Y assets'.\n"
+    "Source patterns and outputs pair 1:1 by index; each may contain at most "
+    "one `*` or `**` wildcard, and the wildcard slots must align (e.g. "
+    '`source = ["context://assets/audio/*.mp3"]` with '
+    '`outputs = ["src/assets/*.mp3"]`). For files the LLM should READ as '
+    "reference (example code, docs, spec snippets), keep using `context_files` "
+    "instead — `context_files` puts the file in the LLM's prompt; `source` "
+    "ships the file unchanged.\n\n"
     "## Incremental re-planning\n"
     "When a spec diff and previous task plan are provided, you are re-planning "
     "after a spec change. Your default mode is PRESERVATION — emit a "
@@ -234,6 +252,10 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     "be able to do later.\n"
     "- context_files: list of filenames from the context directory that this task needs "
     "(empty if none). Only assign files that are directly relevant to the task.\n"
+    "- source: list of `context://<path-or-glob>` patterns whose matched files should be "
+    "copied verbatim into the paired `outputs` paths, without invoking the LLM. Leave "
+    "empty for regular tasks. When set, leave `verify` empty — copy tasks skip "
+    "verification by design.\n"
     "</output_format>\n\n"
     "<examples>\n"
     "<example>\n"
@@ -273,6 +295,21 @@ PLAN_GENERATION_SYSTEM_PROMPT: Final[str] = (
     'verify: ["make clean", "make", "./yep --help > /dev/null", '
     '"./yep --version > /dev/null"]\n'
     "context_files: []\n"
+    "</example>\n"
+    "<example>\n"
+    "A copy-only task that bundles pre-mastered audio assets from the context "
+    "directory. No LLM call, no verify — the build system copies the files "
+    "directly. Source and output patterns pair 1:1 and share the same `*` slot, "
+    "so each matched basename is preserved in the output path:\n\n"
+    'title: "Copy SFX"\n'
+    'description: "Bundle the pre-mastered audio files into the game assets directory."\n'
+    'outputs: ["src/assets/*.mp3"]\n'
+    "depends_on: []\n"
+    'spec_refs: ["Audio Assets"]\n'
+    "arch_refs: []\n"
+    "verify: []\n"
+    "context_files: []\n"
+    'source: ["context://assets/audio/*.mp3"]\n'
     "</example>\n"
     "</examples>"
 )

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -23,6 +23,7 @@ from rich.status import Status
 from rich.text import Text
 
 from ossature.audit.planner import write_plan
+from ossature.build.copy import assemble_copy_task_prompt, build_copy_task
 from ossature.build.prompts import (
     FIXER_SYSTEM_PROMPT,
     IMPLEMENTER_SYSTEM_PROMPT,
@@ -1541,7 +1542,10 @@ def execute_build(
                 continue
 
             if task.status == TaskStatus.DONE:
-                prompt = assemble_task_prompt(task, config, smd_map, amd_by_spec)
+                if task.source:
+                    prompt = assemble_copy_task_prompt(task, config)
+                else:
+                    prompt = assemble_task_prompt(task, config, smd_map, amd_by_spec)
                 current_input_hash = compute_input_hash(prompt, task, config)
                 stored = state.get(task.id)
 
@@ -1620,13 +1624,19 @@ def execute_build(
             _print_task_header(console, task, total, verbose)
 
             # Assemble prompt once — reused for build, retry, and hash storage
-            prompt = assemble_task_prompt(task, config, smd_map, amd_by_spec)
+            if task.source:
+                prompt = assemble_copy_task_prompt(task, config)
+            else:
+                prompt = assemble_task_prompt(task, config, smd_map, amd_by_spec)
 
             # Run task with LLM error recovery
             llm_bail = False
             while True:
                 try:
-                    result = build_task(task, config, prompt, console, status, verbose)
+                    if task.source:
+                        result = build_copy_task(task, config, console, status, verbose)
+                    else:
+                        result = build_task(task, config, prompt, console, status, verbose)
                     break
                 except AgentRunError as e:
                     task.status = TaskStatus.FAILED

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 import re
 import shlex
@@ -854,12 +853,20 @@ def extract_spec_interface(
 ) -> None:
     source_files: list[tuple[str, str]] = []
     for task in plan.tasks:
-        if task.spec == spec_id and task.status == TaskStatus.DONE:
-            for filepath in task.outputs:
-                full_path = config.output_path / filepath
-                if full_path.exists():
-                    with contextlib.suppress(OSError):
-                        source_files.append((filepath, full_path.read_text()))
+        if task.spec != spec_id or task.status != TaskStatus.DONE:
+            continue
+        if task.source:
+            # Copy tasks ship verbatim assets (often binary). They have no
+            # generated-source interface to extract.
+            continue
+        for filepath in task.outputs:
+            full_path = config.output_path / filepath
+            if not full_path.exists():
+                continue
+            try:
+                source_files.append((filepath, full_path.read_text()))
+            except OSError, UnicodeDecodeError:
+                continue
 
     if not source_files:
         return

--- a/src/ossature/build/copy.py
+++ b/src/ossature/build/copy.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.status import Status
+
+from ossature.build.state import make_task_slug
+from ossature.config.loader import OssatureConfig
+from ossature.models.plan import PlanTask
+from ossature.shared.llm import UsageTracker
+
+if TYPE_CHECKING:
+    from ossature.build.builder import TaskResult
+
+
+class CopyTaskError(Exception):
+    """Raised when a copy task cannot be executed."""
+
+
+def _classify_pattern(pattern: str) -> tuple[str, str, str] | None:
+    """Split a pattern into (prefix, wildcard, suffix).
+
+    Returns None for a literal pattern with no wildcard. Raises CopyTaskError
+    if the pattern contains more than one wildcard (`*` or `**`); v1 supports
+    at most one per pattern.
+    """
+    if "**" in pattern:
+        before, _, after = pattern.partition("**")
+        if "**" in after or "*" in before or "*" in after:
+            raise CopyTaskError(
+                f"pattern {pattern!r} has multiple wildcards; "
+                f"v1 supports at most one '*' or '**' per pattern"
+            )
+        return (before, "**", after)
+    if "*" in pattern:
+        before, _, after = pattern.partition("*")
+        if "*" in after:
+            raise CopyTaskError(
+                f"pattern {pattern!r} has multiple wildcards; "
+                f"v1 supports at most one '*' or '**' per pattern"
+            )
+        return (before, "*", after)
+    return None
+
+
+def resolve_source_matches(source: list[str], context_dir: Path) -> list[list[str]]:
+    """For each source pattern, return its sorted matched files relative to context_dir.
+
+    Pure function: no I/O beyond filesystem glob. Returns an empty inner list
+    for patterns with no matches; the caller decides whether that is an error.
+    """
+    if not context_dir.is_dir():
+        return [[] for _ in source]
+    ctx_resolved = context_dir.resolve()
+    result: list[list[str]] = []
+    for pattern in source:
+        matched: list[str] = []
+        for p in sorted(ctx_resolved.glob(pattern)):
+            if not p.is_file():
+                continue
+            resolved = p.resolve()
+            try:
+                rel = resolved.relative_to(ctx_resolved)
+            except ValueError:
+                continue
+            matched.append(str(rel))
+        result.append(matched)
+    return result
+
+
+def map_sources_to_outputs(
+    source: list[str],
+    matches: list[list[str]],
+    outputs: list[str],
+) -> list[tuple[str, str]]:
+    """Pair each matched source file with its destination output path.
+
+    Pairs source[i] with outputs[i] (1:1 by index). For each pair, either both
+    are literals (single file copy) or both share a wildcard slot (basename or
+    path-suffix substitution). Raises CopyTaskError on any ambiguity, empty
+    match set, or count mismatch.
+    """
+    if len(source) != len(outputs):
+        raise CopyTaskError(
+            f"source has {len(source)} entr(ies) but outputs has {len(outputs)}; "
+            f"each source pattern must pair 1:1 with an output pattern"
+        )
+
+    pairs: list[tuple[str, str]] = []
+    for src_pattern, src_matches, out_pattern in zip(source, matches, outputs, strict=True):
+        if not src_matches:
+            raise CopyTaskError(f"source {src_pattern!r} matched no files in the context directory")
+
+        src_wildcard = _classify_pattern(src_pattern)
+        out_wildcard = _classify_pattern(out_pattern)
+
+        if src_wildcard is None:
+            if len(src_matches) != 1:
+                raise CopyTaskError(
+                    f"literal source {src_pattern!r} resolved to {len(src_matches)} files"
+                )
+            if out_wildcard is not None:
+                raise CopyTaskError(
+                    f"source {src_pattern!r} is literal but paired output "
+                    f"{out_pattern!r} has a wildcard"
+                )
+            pairs.append((src_matches[0], out_pattern))
+            continue
+
+        if out_wildcard is None:
+            raise CopyTaskError(
+                f"source {src_pattern!r} has a wildcard but paired output "
+                f"{out_pattern!r} does not; add a matching wildcard to the output"
+            )
+
+        src_prefix, _, src_suffix = src_wildcard
+        out_prefix, _, out_suffix = out_wildcard
+        for matched in src_matches:
+            if not matched.startswith(src_prefix):
+                raise CopyTaskError(
+                    f"matched file {matched!r} does not fit source pattern {src_pattern!r}"
+                )
+            if src_suffix and not matched.endswith(src_suffix):
+                raise CopyTaskError(
+                    f"matched file {matched!r} does not fit source pattern {src_pattern!r}"
+                )
+            captured_end = len(matched) - len(src_suffix) if src_suffix else len(matched)
+            captured = matched[len(src_prefix) : captured_end]
+            dest = f"{out_prefix}{captured}{out_suffix}"
+            pairs.append((matched, dest))
+
+    return pairs
+
+
+def assemble_copy_task_prompt(task: PlanTask, config: OssatureConfig) -> str:
+    """Build a deterministic synthetic prompt for a copy task.
+
+    Used as the input-hash seed in place of the LLM prompt. Includes the source
+    patterns, the outputs, and the currently-matched files so the input hash
+    changes when any of these change.
+    """
+    lines: list[str] = []
+    lines.append("<copy_task>")
+    lines.append(f"id: {task.id}")
+    lines.append(f"title: {task.title}")
+    lines.append("source:")
+    for s in task.source:
+        lines.append(f"- context://{s}")
+    lines.append("outputs:")
+    for o in task.outputs:
+        lines.append(f"- {o}")
+    matches = resolve_source_matches(task.source, config.context_path)
+    flat = sorted({m for sub in matches for m in sub})
+    lines.append("matched_sources:")
+    for m in flat:
+        lines.append(f"- {m}")
+    lines.append("</copy_task>")
+    return "\n".join(lines)
+
+
+def build_copy_task(
+    task: PlanTask,
+    config: OssatureConfig,
+    console: Console,
+    status: Status,
+    verbose: bool = False,
+) -> TaskResult:
+    """Execute a copy-only task: copy files from context to output, no LLM call."""
+    from ossature.build.builder import TaskResult, save_task_output
+
+    slug = make_task_slug(task)
+    task_dir = config.metadata_path / "tasks" / f"{task.id}-{slug}"
+    task_dir.mkdir(parents=True, exist_ok=True)
+
+    task_label = f"[{task.id}] {task.title}"
+    status.update(f"{task_label} -- copying...")
+
+    prompt = assemble_copy_task_prompt(task, config)
+    (task_dir / "prompt.md").write_text(prompt)
+
+    t0 = time.monotonic()
+
+    def _fail(message: str, created_so_far: list[str]) -> TaskResult:
+        (task_dir / "response.md").write_text(f"[copy task error] {message}\n")
+        save_task_output(task_dir, created_so_far, [], False, message)
+        return TaskResult(
+            success=False,
+            file_count=len(created_so_far),
+            total_lines=0,
+            elapsed=time.monotonic() - t0,
+            created_files=created_so_far,
+            edited_files=[],
+            usage=UsageTracker(),
+        )
+
+    if not task.source:
+        return _fail(f"copy task {task.id} has no source patterns", [])
+
+    if not config.context_path.is_dir():
+        return _fail(
+            f"copy task {task.id} requires context directory "
+            f"{config.context_path} but it does not exist",
+            [],
+        )
+
+    try:
+        matches = resolve_source_matches(task.source, config.context_path)
+        pairs = map_sources_to_outputs(task.source, matches, task.outputs)
+    except CopyTaskError as e:
+        return _fail(str(e), [])
+
+    created_files: list[str] = []
+    output_dir_resolved = config.output_path.resolve()
+    context_dir_resolved = config.context_path.resolve()
+
+    for src_rel, dst_rel in pairs:
+        src_full = (context_dir_resolved / src_rel).resolve()
+        if not src_full.is_relative_to(context_dir_resolved):
+            return _fail(
+                f"source {src_rel!r} resolves outside the context directory",
+                created_files,
+            )
+        if not src_full.exists() or not src_full.is_file():
+            return _fail(f"source file {src_rel!r} does not exist", created_files)
+
+        dst_full = (output_dir_resolved / dst_rel).resolve()
+        if not dst_full.is_relative_to(output_dir_resolved):
+            return _fail(
+                f"output {dst_rel!r} resolves outside the output directory",
+                created_files,
+            )
+
+        status.update(f"{task_label} -- copying {src_rel} -> {dst_rel}")
+        try:
+            dst_full.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(src_full), str(dst_full))
+        except OSError as e:
+            return _fail(f"failed copying {src_rel!r} to {dst_rel!r}: {e}", created_files)
+
+        if dst_rel not in created_files:
+            created_files.append(dst_rel)
+        if verbose:
+            console.log(f"      copied [bold]{src_rel}[/bold] -> [bold]{dst_rel}[/bold]")
+
+    summary_line = f"Copied {len(created_files)} file(s) from context to output."
+    response_body = summary_line + "\n\n" + "\n".join(f"- {s} -> {d}" for s, d in pairs) + "\n"
+    (task_dir / "response.md").write_text(response_body)
+    save_task_output(task_dir, created_files, [], True, summary_line)
+
+    return TaskResult(
+        success=True,
+        file_count=len(created_files),
+        total_lines=0,
+        elapsed=time.monotonic() - t0,
+        created_files=created_files,
+        edited_files=[],
+        usage=UsageTracker(),
+    )

--- a/src/ossature/build/state.py
+++ b/src/ossature/build/state.py
@@ -38,6 +38,11 @@ def compute_input_hash(prompt: str, task: PlanTask, config: OssatureConfig) -> s
     inject_files are NOT hashed here — dependency rebuilds are detected by
     tracking rebuilt task IDs in the build loop, which avoids false invalidation
     when a later task edits an injected file.
+
+    For copy tasks (task.source non-empty), the matched source-file bytes are
+    folded in here so the hash changes when any matched file's content changes.
+    The set of matched files is already captured in the synthetic prompt that
+    callers pass for copy tasks.
     """
     hasher = hashlib.new(HASH_ALGO)
     hasher.update(prompt.encode())
@@ -46,6 +51,16 @@ def compute_input_hash(prompt: str, task: PlanTask, config: OssatureConfig) -> s
         if full_path.exists():
             hasher.update(f"context:{filepath}".encode())
             hasher.update(full_path.read_bytes())
+    if task.source:
+        from ossature.build.copy import resolve_source_matches
+
+        matches = resolve_source_matches(task.source, config.context_path)
+        for sub in matches:
+            for rel in sub:
+                full_path = config.context_path / rel
+                if full_path.exists():
+                    hasher.update(f"source:{rel}".encode())
+                    hasher.update(full_path.read_bytes())
     return f"{HASH_ALGO}:{hasher.hexdigest()}"
 
 

--- a/src/ossature/cli/commands/status.py
+++ b/src/ossature/cli/commands/status.py
@@ -45,9 +45,12 @@ def run_status(
         elif task.status == TaskStatus.PENDING:
             spec_stats[task.spec]["pending"] += 1
 
+    # Derive counts from plan.tasks rather than plan.meta so the header always
+    # matches the per-spec table, even if meta.total_tasks is stale (e.g. after
+    # a manual plan.toml edit).
+    actual_specs = {t.spec for t in plan.tasks} | set(plan.meta.specs)
     console.print(
-        f"[bold]{config.name}[/bold] — "
-        f"{len(plan.meta.specs)} specs, {plan.meta.total_tasks} tasks\n"
+        f"[bold]{config.name}[/bold] — {len(actual_specs)} specs, {len(plan.tasks)} tasks\n"
     )
 
     tbl = Table(show_header=True, expand=False, pad_edge=False)

--- a/src/ossature/models/plan.py
+++ b/src/ossature/models/plan.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from typing import Annotated, Any, Literal
 
@@ -28,6 +29,52 @@ def _coerce_verify(value: Any) -> list[str]:
     raise TypeError(f"verify must be a string or a list of strings, got {type(value).__name__}")
 
 
+_SOURCE_SCHEME_PATTERN = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://")
+
+
+def _normalize_source(value: Any) -> list[str]:
+    """Normalize a `source` field to a list of context-relative path patterns.
+
+    Accepts None, a single string, or a list of strings. Each entry may
+    optionally use a `context://` URL-scheme prefix; the prefix is stripped
+    here so internal callers always see plain context-relative paths.
+    Other schemes are rejected, as are absolute paths and parent-directory
+    traversal.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        items = [value]
+    elif isinstance(value, list):
+        items = [str(item) for item in value]
+    else:
+        raise TypeError(f"source must be a string or a list of strings, got {type(value).__name__}")
+
+    normalized: list[str] = []
+    for raw in items:
+        if not raw:
+            raise ValueError("source entries must be non-empty strings")
+        scheme_match = _SOURCE_SCHEME_PATTERN.match(raw)
+        if scheme_match:
+            scheme = scheme_match.group(1)
+            if scheme != "context":
+                raise ValueError(
+                    f"source scheme {scheme!r} is not supported; only 'context://' is allowed"
+                )
+            path = raw[scheme_match.end() :]
+        else:
+            path = raw
+        if not path:
+            raise ValueError(f"source entry {raw!r} has no path after the scheme prefix")
+        if path.startswith("/"):
+            raise ValueError(f"source entry {raw!r} must be a context-relative path, not absolute")
+        parts = path.replace("\\", "/").split("/")
+        if any(part == ".." for part in parts):
+            raise ValueError(f"source entry {raw!r} must not contain '..' path traversal segments")
+        normalized.append(path)
+    return normalized
+
+
 class PlannerTask(BaseModel):
     kind: Literal["task"] = "task"
     title: str
@@ -38,11 +85,17 @@ class PlannerTask(BaseModel):
     arch_refs: list[str]
     verify: list[str]
     context_files: list[str] = []
+    source: list[str] = []
 
     @field_validator("verify", mode="before")
     @classmethod
     def _normalize_verify(cls, value: Any) -> list[str]:
         return _coerce_verify(value)
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def _normalize_source(cls, value: Any) -> list[str]:
+        return _normalize_source(value)
 
 
 class PreservedTaskRef(BaseModel):
@@ -71,12 +124,18 @@ class PlanTask(BaseModel):
     inject_files: list[str] = []
     cross_spec_interfaces: list[str] = []
     context_files: list[str] = []
+    source: list[str] = []
     notes: str = ""
 
     @field_validator("verify", mode="before")
     @classmethod
     def _normalize_verify(cls, value: Any) -> list[str]:
         return _coerce_verify(value)
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def _normalize_source(cls, value: Any) -> list[str]:
+        return _normalize_source(value)
 
 
 class PlanMeta(BaseModel):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -110,6 +110,7 @@ def make_spec_task_plan(tasks: list[dict]) -> SpecTaskPlan:
                 spec_refs=t.get("spec_refs", []),
                 arch_refs=t.get("arch_refs", []),
                 verify=t.get("verify", ""),
+                source=t.get("source", []),
             )
             for t in tasks
         ]

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -6,7 +6,7 @@ from conftest import make_plan, make_task
 
 from ossature.audit.planner import write_plan
 from ossature.cli.main import cli
-from ossature.models.plan import TaskStatus
+from ossature.models.plan import PlanMeta, TaskStatus
 
 
 class TestStatusCommand:
@@ -107,3 +107,31 @@ class TestStatusCommand:
         assert result.exit_code == 0
         assert "AUTH" in result.output
         assert "API" in result.output
+
+    def test_stale_meta_total_tasks_does_not_mislead_header(
+        self, runner: CliRunner, project_dir: Path
+    ):
+        """If plan.meta.total_tasks is out of sync with len(plan.tasks) (e.g.
+        from a manual plan.toml edit), the header should reflect the actual
+        task list, not the stale meta."""
+        plan = make_plan(
+            [
+                make_task("1", "AUTH", status=TaskStatus.DONE),
+                make_task("2", "AUTH", status=TaskStatus.DONE),
+            ]
+        )
+        # Force a stale meta total_tasks
+        plan.meta = PlanMeta(
+            generated_at=plan.meta.generated_at,
+            total_tasks=99,
+            specs=plan.meta.specs,
+        )
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan(plan, plan_path)
+
+        result = self._run(runner, project_dir)
+
+        assert result.exit_code == 0
+        assert "2 tasks" in result.output
+        assert "99 tasks" not in result.output

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -750,3 +750,48 @@ class TestBuildWorkflow:
 
         assert result.exit_code == 1
         assert "No plan found" in result.output
+
+    def test_build_copy_task_copies_files_without_llm(
+        self,
+        runner: CliRunner,
+        project_dir: Path,
+    ):
+        write_smd(project_dir, "ASSETS", "Assets Module")
+        (project_dir / "context" / "logo.txt").write_text("LOGO DATA")
+        copy_plan = make_spec_task_plan(
+            [
+                {
+                    "title": "Copy logo",
+                    "outputs": ["assets/logo.txt"],
+                    "source": ["context://logo.txt"],
+                },
+                {"title": "App code", "outputs": ["src/app.py"], "depends_on": [1]},
+            ]
+        )
+        self._run_audit(runner, project_dir, {"ASSETS": copy_plan})
+
+        with patch_all_agents({"ASSETS": copy_plan}):
+            result = run_in_project(runner, project_dir, ["build", "--auto"])
+
+        assert result.exit_code == 0
+        copied = project_dir / "output" / "assets" / "logo.txt"
+        assert copied.exists()
+        assert copied.read_text() == "LOGO DATA"
+
+        plan_path = project_dir / ".ossature" / "plan.toml"
+        plan = load_plan(plan_path)
+        assert plan is not None
+        assert all(t.status == TaskStatus.DONE for t in plan.tasks)
+
+        # Flip the second task back to pending and rebuild. execute_build now
+        # iterates the already-DONE copy task, exercising its done-path branch.
+        plan.tasks[1].status = TaskStatus.PENDING
+        write_plan(plan, plan_path)
+
+        with patch_all_agents({"ASSETS": copy_plan}):
+            result2 = run_in_project(runner, project_dir, ["build", "--auto"])
+        assert result2.exit_code == 0
+        # Copy output untouched, copy task still done
+        assert copied.read_text() == "LOGO DATA"
+        plan2 = load_plan(plan_path)
+        assert plan2.tasks[0].status == TaskStatus.DONE

--- a/tests/unit/test_build_copy.py
+++ b/tests/unit/test_build_copy.py
@@ -1,0 +1,277 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import tomli
+from conftest import make_config
+
+from ossature.build.copy import (
+    CopyTaskError,
+    _classify_pattern,
+    assemble_copy_task_prompt,
+    build_copy_task,
+    map_sources_to_outputs,
+    resolve_source_matches,
+)
+from ossature.models.plan import PlanTask, TaskStatus
+
+
+def _copy_task(
+    task_id: str = "001",
+    title: str = "Copy assets",
+    source: list[str] | None = None,
+    outputs: list[str] | None = None,
+) -> PlanTask:
+    return PlanTask(
+        id=task_id,
+        spec="AUDIO",
+        title=title,
+        description="copy task",
+        outputs=outputs or [],
+        depends_on=[],
+        spec_refs=[],
+        arch_refs=[],
+        status=TaskStatus.PENDING,
+        verify=[],
+        source=source or [],
+    )
+
+
+def _setup_project(temp_dir: Path, files: dict[str, bytes]) -> None:
+    context = temp_dir / "context"
+    output = temp_dir / "output"
+    context.mkdir(parents=True, exist_ok=True)
+    output.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        full = context / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_bytes(content)
+
+
+class TestClassifyPattern:
+    def test_literal_pattern_returns_none(self):
+        assert _classify_pattern("assets/foo.mp3") is None
+
+    def test_single_star(self):
+        assert _classify_pattern("assets/*.mp3") == ("assets/", "*", ".mp3")
+
+    def test_double_star(self):
+        assert _classify_pattern("assets/**/foo.mp3") == ("assets/", "**", "/foo.mp3")
+
+    def test_multiple_stars_raises(self):
+        with pytest.raises(CopyTaskError):
+            _classify_pattern("a/*/b/*.mp3")
+
+    def test_mixed_star_and_double_star_raises(self):
+        with pytest.raises(CopyTaskError):
+            _classify_pattern("a/**/b/*.mp3")
+
+
+class TestResolveSourceMatches:
+    def test_literal_match(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"x"})
+        matches = resolve_source_matches(["a.mp3"], temp_dir / "context")
+        assert matches == [["a.mp3"]]
+
+    def test_glob_match_sorted(self, temp_dir: Path):
+        _setup_project(temp_dir, {"audio/b.mp3": b"x", "audio/a.mp3": b"y"})
+        matches = resolve_source_matches(["audio/*.mp3"], temp_dir / "context")
+        assert matches == [["audio/a.mp3", "audio/b.mp3"]]
+
+    def test_recursive_glob(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a/b/c.mp3": b"x", "a/d.mp3": b"y"})
+        matches = resolve_source_matches(["**/*.mp3"], temp_dir / "context")
+        assert sorted(matches[0]) == ["a/b/c.mp3", "a/d.mp3"]
+
+    def test_no_match_returns_empty_inner(self, temp_dir: Path):
+        _setup_project(temp_dir, {})
+        matches = resolve_source_matches(["*.mp3"], temp_dir / "context")
+        assert matches == [[]]
+
+    def test_missing_context_dir_returns_empty(self, temp_dir: Path):
+        matches = resolve_source_matches(["*.mp3"], temp_dir / "no-such-dir")
+        assert matches == [[]]
+
+    def test_multiple_patterns(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"", "b.png": b""})
+        matches = resolve_source_matches(["*.mp3", "*.png"], temp_dir / "context")
+        assert matches == [["a.mp3"], ["b.png"]]
+
+
+class TestMapSourcesToOutputs:
+    def test_literal_one_to_one(self):
+        pairs = map_sources_to_outputs(["a.json"], [["a.json"]], ["dest/a.json"])
+        assert pairs == [("a.json", "dest/a.json")]
+
+    def test_glob_basename_substitution(self):
+        pairs = map_sources_to_outputs(
+            ["audio/*.mp3"],
+            [["audio/foo.mp3", "audio/bar.mp3"]],
+            ["src/*.mp3"],
+        )
+        assert sorted(pairs) == [("audio/bar.mp3", "src/bar.mp3"), ("audio/foo.mp3", "src/foo.mp3")]
+
+    def test_recursive_glob_substitution(self):
+        pairs = map_sources_to_outputs(
+            ["assets/**"],
+            [["assets/a/b.mp3", "assets/c.mp3"]],
+            ["out/**"],
+        )
+        assert sorted(pairs) == [("assets/a/b.mp3", "out/a/b.mp3"), ("assets/c.mp3", "out/c.mp3")]
+
+    def test_zero_matches_raises(self):
+        with pytest.raises(CopyTaskError, match="matched no files"):
+            map_sources_to_outputs(["*.mp3"], [[]], ["out/*.mp3"])
+
+    def test_count_mismatch_raises(self):
+        with pytest.raises(CopyTaskError, match="entr"):
+            map_sources_to_outputs(["a", "b"], [["a"], ["b"]], ["only-one"])
+
+    def test_literal_source_with_wildcard_output_raises(self):
+        with pytest.raises(CopyTaskError, match="wildcard"):
+            map_sources_to_outputs(["a.mp3"], [["a.mp3"]], ["out/*.mp3"])
+
+    def test_wildcard_source_with_literal_output_raises(self):
+        with pytest.raises(CopyTaskError, match="wildcard"):
+            map_sources_to_outputs(["*.mp3"], [["foo.mp3"]], ["out.mp3"])
+
+    def test_literal_source_multiple_matches_raises(self):
+        with pytest.raises(CopyTaskError, match="resolved to"):
+            map_sources_to_outputs(["a.mp3"], [["a.mp3", "b.mp3"]], ["out.mp3"])
+
+    def test_multiple_paired_patterns(self):
+        pairs = map_sources_to_outputs(
+            ["audio/*.mp3", "images/*.png"],
+            [["audio/foo.mp3"], ["images/bar.png"]],
+            ["src/*.mp3", "img/*.png"],
+        )
+        assert ("audio/foo.mp3", "src/foo.mp3") in pairs
+        assert ("images/bar.png", "img/bar.png") in pairs
+
+
+class TestAssembleCopyTaskPrompt:
+    def test_includes_source_outputs_and_matches(self, temp_dir: Path):
+        _setup_project(temp_dir, {"audio/a.mp3": b"x", "audio/b.mp3": b"y"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://audio/*.mp3"], outputs=["src/assets/*.mp3"])
+        prompt = assemble_copy_task_prompt(task, config)
+        assert "context://audio/*.mp3" in prompt
+        assert "src/assets/*.mp3" in prompt
+        assert "audio/a.mp3" in prompt
+        assert "audio/b.mp3" in prompt
+
+    def test_deterministic(self, temp_dir: Path):
+        _setup_project(temp_dir, {"audio/a.mp3": b"x", "audio/b.mp3": b"y"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://audio/*.mp3"], outputs=["src/*.mp3"])
+        assert assemble_copy_task_prompt(task, config) == assemble_copy_task_prompt(task, config)
+
+    def test_changes_when_matches_change(self, temp_dir: Path):
+        _setup_project(temp_dir, {"audio/a.mp3": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://audio/*.mp3"], outputs=["src/*.mp3"])
+        before = assemble_copy_task_prompt(task, config)
+
+        (temp_dir / "context" / "audio" / "c.mp3").write_bytes(b"z")
+        after = assemble_copy_task_prompt(task, config)
+        assert before != after
+
+
+class TestBuildCopyTask:
+    def test_single_file_copy(self, temp_dir: Path):
+        _setup_project(temp_dir, {"config.json": b'{"k": 1}'})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://config.json"], outputs=["src/config.json"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is True
+        assert result.created_files == ["src/config.json"]
+        assert (temp_dir / "output" / "src" / "config.json").read_bytes() == b'{"k": 1}'
+
+    def test_glob_copy_creates_all_matches(self, temp_dir: Path):
+        _setup_project(temp_dir, {"audio/a.mp3": b"AAA", "audio/b.mp3": b"BBB"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://audio/*.mp3"], outputs=["src/assets/*.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is True
+        assert sorted(result.created_files) == ["src/assets/a.mp3", "src/assets/b.mp3"]
+        assert (temp_dir / "output" / "src" / "assets" / "a.mp3").read_bytes() == b"AAA"
+        assert (temp_dir / "output" / "src" / "assets" / "b.mp3").read_bytes() == b"BBB"
+
+    def test_zero_matches_fails(self, temp_dir: Path):
+        _setup_project(temp_dir, {})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://audio/*.mp3"], outputs=["src/*.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+        assert result.created_files == []
+
+    def test_missing_context_dir_fails(self, temp_dir: Path):
+        # No context dir created
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.mp3"], outputs=["src/a.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+
+    def test_empty_source_fails(self, temp_dir: Path):
+        _setup_project(temp_dir, {})
+        config = make_config(temp_dir)
+        task = _copy_task(source=[], outputs=["src/a.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+
+    def test_creates_intermediate_directories(self, temp_dir: Path):
+        _setup_project(temp_dir, {"deep/a.bin": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://deep/a.bin"], outputs=["deep/nested/dest/a.bin"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is True
+        assert (temp_dir / "output" / "deep" / "nested" / "dest" / "a.bin").exists()
+
+    def test_overwrites_existing_destination(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"NEW"})
+        (temp_dir / "output" / "src").mkdir(parents=True)
+        (temp_dir / "output" / "src" / "a.mp3").write_bytes(b"OLD")
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.mp3"], outputs=["src/a.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is True
+        assert (temp_dir / "output" / "src" / "a.mp3").read_bytes() == b"NEW"
+
+    def test_writes_prompt_and_response_files(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.mp3"], outputs=["src/a.mp3"])
+        build_copy_task(task, config, MagicMock(), MagicMock())
+        task_dir = temp_dir / ".ossature" / "tasks" / "001-copy-assets"
+        assert (task_dir / "prompt.md").exists()
+        assert (task_dir / "response.md").exists()
+        assert (task_dir / "output.toml").exists()
+
+    def test_output_toml_records_created_files_and_success(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.mp3"], outputs=["src/a.mp3"])
+        build_copy_task(task, config, MagicMock(), MagicMock())
+        out = tomli.loads(
+            (temp_dir / ".ossature" / "tasks" / "001-copy-assets" / "output.toml").read_text()
+        )
+        assert out["success"] is True
+        assert out["created_files"] == ["src/a.mp3"]
+
+    def test_task_result_summary_includes_file_count(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.mp3": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.mp3"], outputs=["src/a.mp3"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.file_count == 1
+        assert result.total_lines == 0
+
+    def test_failed_copy_writes_output_toml_with_success_false(self, temp_dir: Path):
+        _setup_project(temp_dir, {})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://nope/*.mp3"], outputs=["src/*.mp3"])
+        build_copy_task(task, config, MagicMock(), MagicMock())
+        out = tomli.loads(
+            (temp_dir / ".ossature" / "tasks" / "001-copy-assets" / "output.toml").read_text()
+        )
+        assert out["success"] is False

--- a/tests/unit/test_build_copy.py
+++ b/tests/unit/test_build_copy.py
@@ -5,6 +5,7 @@ import pytest
 import tomli
 from conftest import make_config
 
+import ossature.build.copy as copy_mod
 from ossature.build.copy import (
     CopyTaskError,
     _classify_pattern,
@@ -97,6 +98,25 @@ class TestResolveSourceMatches:
         matches = resolve_source_matches(["*.mp3", "*.png"], temp_dir / "context")
         assert matches == [["a.mp3"], ["b.png"]]
 
+    def test_glob_skips_directories(self, temp_dir: Path):
+        """A directory whose name matches the glob must not be treated as a match."""
+        _setup_project(temp_dir, {"audio/a.mp3": b"x"})
+        (temp_dir / "context" / "audio" / "subdir.mp3").mkdir()
+        matches = resolve_source_matches(["audio/*.mp3"], temp_dir / "context")
+        assert matches == [["audio/a.mp3"]]
+
+    def test_skips_symlink_escaping_context(self, temp_dir: Path):
+        """A symlink inside the context dir that resolves to a file outside it
+        must be skipped, not copied (it would leak files from outside)."""
+        context = temp_dir / "context"
+        context.mkdir(parents=True)
+        outside = temp_dir / "outside.txt"
+        outside.write_bytes(b"secret")
+        (context / "link.txt").symlink_to(outside)
+
+        matches = resolve_source_matches(["*.txt"], context)
+        assert matches == [[]]
+
 
 class TestMapSourcesToOutputs:
     def test_literal_one_to_one(self):
@@ -147,6 +167,14 @@ class TestMapSourcesToOutputs:
         )
         assert ("audio/foo.mp3", "src/foo.mp3") in pairs
         assert ("images/bar.png", "img/bar.png") in pairs
+
+    def test_matched_file_not_matching_prefix_raises(self):
+        with pytest.raises(CopyTaskError, match="does not fit"):
+            map_sources_to_outputs(["audio/*.mp3"], [["other/foo.mp3"]], ["out/*.mp3"])
+
+    def test_matched_file_not_matching_suffix_raises(self):
+        with pytest.raises(CopyTaskError, match="does not fit"):
+            map_sources_to_outputs(["audio/*.mp3"], [["audio/foo.wav"]], ["out/*.mp3"])
 
 
 class TestAssembleCopyTaskPrompt:
@@ -275,3 +303,58 @@ class TestBuildCopyTask:
             (temp_dir / ".ossature" / "tasks" / "001-copy-assets" / "output.toml").read_text()
         )
         assert out["success"] is False
+
+    def test_output_escaping_output_dir_fails(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.txt": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.txt"], outputs=["../escape.txt"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+        assert not (temp_dir / "escape.txt").exists()
+
+    def test_copy_oserror_fails_gracefully(self, temp_dir: Path):
+        """If a destination's parent path is occupied by a file, mkdir raises
+        OSError — the task fails cleanly instead of crashing."""
+        _setup_project(temp_dir, {"a.txt": b"x"})
+        (temp_dir / "output" / "dest").write_text("i am a file, not a directory")
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.txt"], outputs=["dest/a.txt"])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+
+    def test_verbose_logs_copied_files(self, temp_dir: Path):
+        _setup_project(temp_dir, {"a.txt": b"x"})
+        config = make_config(temp_dir)
+        console = MagicMock()
+        task = _copy_task(source=["context://a.txt"], outputs=["a.txt"])
+        result = build_copy_task(task, config, console, MagicMock(), verbose=True)
+        assert result.success is True
+        console.log.assert_called()
+
+    def test_source_resolving_outside_context_fails(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Defensive guard: if a matched source path escapes the context dir
+        (e.g. via a symlinked path component appearing after match resolution),
+        the copy aborts instead of reading outside the sandbox."""
+        _setup_project(temp_dir, {"a.txt": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://a.txt"], outputs=["a.txt"])
+        monkeypatch.setattr(
+            copy_mod, "resolve_source_matches", lambda src, ctx: [["../outside.txt"]]
+        )
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False
+
+    def test_source_file_missing_at_copy_time_fails(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Defensive guard: if a matched source file no longer exists when the
+        copy loop runs (TOCTOU between match resolution and copy), the copy
+        aborts cleanly."""
+        _setup_project(temp_dir, {"a.txt": b"x"})
+        config = make_config(temp_dir)
+        task = _copy_task(source=["context://ghost.txt"], outputs=["ghost.txt"])
+        monkeypatch.setattr(copy_mod, "resolve_source_matches", lambda src, ctx: [["ghost.txt"]])
+        result = build_copy_task(task, config, MagicMock(), MagicMock())
+        assert result.success is False

--- a/tests/unit/test_build_interface_extraction.py
+++ b/tests/unit/test_build_interface_extraction.py
@@ -115,6 +115,70 @@ class TestExtractSpecInterface:
         assert "src/service.py" in prompt
 
     @patch("ossature.build.builder.Agent")
+    def test_skips_copy_task_outputs(self, mock_agent_cls, temp_dir: Path):
+        """Copy tasks ship verbatim assets (often binary) and have no
+        generated-source interface to extract. Their outputs must be skipped
+        even when they happen to be text, and binary outputs must not crash."""
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        (output_dir / "src").mkdir()
+        (output_dir / "src" / "auth.py").write_text("class Auth: pass")
+        (output_dir / "correct.wav").write_bytes(b"\x91\x00\xff binary audio")
+
+        config = make_config(temp_dir)
+        copy_task = make_task("001", "AUTH", outputs=["correct.wav"], status=TaskStatus.DONE)
+        copy_task.source = ["correct.wav"]
+        plan = make_plan(
+            [
+                copy_task,
+                make_task("002", "AUTH", outputs=["src/auth.py"], status=TaskStatus.DONE),
+            ]
+        )
+
+        mock_result = MagicMock()
+        mock_result.output = "interface"
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run_sync.return_value = mock_result
+        mock_agent_cls.return_value = mock_agent_instance
+
+        extract_spec_interface("AUTH", plan, config, MagicMock(), MagicMock())
+
+        prompt = mock_agent_instance.run_sync.call_args[0][0]
+        assert "src/auth.py" in prompt
+        assert "correct.wav" not in prompt
+
+    @patch("ossature.build.builder.Agent")
+    def test_skips_binary_output_without_source_field(self, mock_agent_cls, temp_dir: Path):
+        """Defensive: even a non-copy task with a binary output shouldn't crash
+        interface extraction (e.g., a build.setup script that wrote a binary)."""
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        (output_dir / "src").mkdir()
+        (output_dir / "src" / "auth.py").write_text("class Auth: pass")
+        (output_dir / "blob.bin").write_bytes(b"\x91\x00\xff")
+
+        config = make_config(temp_dir)
+        plan = make_plan(
+            [
+                make_task("001", "AUTH", outputs=["blob.bin"], status=TaskStatus.DONE),
+                make_task("002", "AUTH", outputs=["src/auth.py"], status=TaskStatus.DONE),
+            ]
+        )
+
+        mock_result = MagicMock()
+        mock_result.output = "interface"
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run_sync.return_value = mock_result
+        mock_agent_cls.return_value = mock_agent_instance
+
+        # Must not raise UnicodeDecodeError
+        extract_spec_interface("AUTH", plan, config, MagicMock(), MagicMock())
+
+        prompt = mock_agent_instance.run_sync.call_args[0][0]
+        assert "src/auth.py" in prompt
+        assert "blob.bin" not in prompt
+
+    @patch("ossature.build.builder.Agent")
     def test_only_collects_from_target_spec(self, mock_agent_cls, temp_dir: Path):
         output_dir = temp_dir / "output"
         (output_dir / "src").mkdir(parents=True)

--- a/tests/unit/test_build_state.py
+++ b/tests/unit/test_build_state.py
@@ -51,6 +51,41 @@ class TestComputeInputHash:
 
         assert h1 == h2
 
+    def test_source_file_content_change_invalidates_hash(self, temp_dir: Path):
+        ctx = temp_dir / "context"
+        ctx.mkdir(parents=True)
+        (ctx / "a.mp3").write_bytes(b"v1")
+        config = make_config(temp_dir)
+        task = make_task("001", "AUDIO")
+        task.source = ["a.mp3"]
+        h1 = compute_input_hash("same prompt", task, config)
+
+        (ctx / "a.mp3").write_bytes(b"v2")
+        h2 = compute_input_hash("same prompt", task, config)
+        assert h1 != h2
+
+    def test_source_match_set_change_invalidates_hash(self, temp_dir: Path):
+        ctx = temp_dir / "context"
+        (ctx / "audio").mkdir(parents=True)
+        (ctx / "audio" / "a.mp3").write_bytes(b"x")
+        config = make_config(temp_dir)
+        task = make_task("001", "AUDIO")
+        task.source = ["audio/*.mp3"]
+        h1 = compute_input_hash("same prompt", task, config)
+
+        (ctx / "audio" / "b.mp3").write_bytes(b"y")
+        h2 = compute_input_hash("same prompt", task, config)
+        assert h1 != h2
+
+    def test_non_source_task_hash_unchanged_by_source_addition(self, temp_dir: Path):
+        """Regression: tasks without source must produce identical hashes to before."""
+        config = make_config(temp_dir)
+        task = make_task("001", "AUTH")
+        # source defaults to [] so the new code path is gated off
+        h = compute_input_hash("prompt", task, config)
+        assert h.startswith("sha256:")
+        assert h == compute_input_hash("prompt", task, config)
+
 
 class TestComputeOutputHash:
     def test_same_files_same_hash(self, temp_dir: Path):

--- a/tests/unit/test_models_plan.py
+++ b/tests/unit/test_models_plan.py
@@ -101,3 +101,7 @@ class TestSourceFieldValidation:
     def test_planner_task_same_validation(self):
         with pytest.raises(ValidationError):
             PlannerTask(**_make_planner_task(source=["file:///etc/passwd"]))
+
+    def test_rejects_non_string_non_list_type(self):
+        with pytest.raises(Exception, match="source must be a string or a list"):
+            PlanTask(**_make_plan_task(source=42))

--- a/tests/unit/test_models_plan.py
+++ b/tests/unit/test_models_plan.py
@@ -1,0 +1,103 @@
+import pytest
+from pydantic import ValidationError
+
+from ossature.models.plan import PlannerTask, PlanTask
+
+
+def _make_plan_task(**overrides) -> dict:
+    base = {
+        "id": "001",
+        "spec": "AUDIO",
+        "title": "Copy SFX",
+        "description": "Bundle audio assets",
+        "outputs": ["src/assets/*.mp3"],
+        "depends_on": [],
+        "spec_refs": [],
+        "arch_refs": [],
+        "verify": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_planner_task(**overrides) -> dict:
+    base = {
+        "title": "Copy SFX",
+        "description": "Bundle audio assets",
+        "outputs": ["src/assets/*.mp3"],
+        "depends_on": [],
+        "spec_refs": [],
+        "arch_refs": [],
+        "verify": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSourceFieldDefaults:
+    def test_plan_task_default_source_empty(self):
+        task = PlanTask(**_make_plan_task())
+        assert task.source == []
+
+    def test_planner_task_default_source_empty(self):
+        task = PlannerTask(**_make_planner_task())
+        assert task.source == []
+
+
+class TestSourceFieldNormalization:
+    def test_strips_context_prefix(self):
+        task = PlanTask(**_make_plan_task(source=["context://assets/audio/*.mp3"]))
+        assert task.source == ["assets/audio/*.mp3"]
+
+    def test_accepts_path_without_prefix(self):
+        task = PlanTask(**_make_plan_task(source=["assets/audio/foo.mp3"]))
+        assert task.source == ["assets/audio/foo.mp3"]
+
+    def test_accepts_single_string_as_list(self):
+        task = PlanTask(**_make_plan_task(source="context://assets/foo.mp3"))
+        assert task.source == ["assets/foo.mp3"]
+
+    def test_accepts_none_as_empty(self):
+        task = PlanTask(**_make_plan_task(source=None))
+        assert task.source == []
+
+    def test_normalizes_multiple_entries(self):
+        task = PlanTask(**_make_plan_task(source=["context://a/b.mp3", "c/d.mp3"]))
+        assert task.source == ["a/b.mp3", "c/d.mp3"]
+
+
+class TestSourceFieldValidation:
+    def test_rejects_foreign_scheme(self):
+        with pytest.raises(ValidationError) as exc_info:
+            PlanTask(**_make_plan_task(source=["file:///etc/passwd"]))
+        assert "scheme" in str(exc_info.value).lower()
+
+    def test_rejects_http_scheme(self):
+        with pytest.raises(ValidationError):
+            PlanTask(**_make_plan_task(source=["http://example.com/x.mp3"]))
+
+    def test_rejects_absolute_path(self):
+        with pytest.raises(ValidationError) as exc_info:
+            PlanTask(**_make_plan_task(source=["/abs/path.mp3"]))
+        assert "absolute" in str(exc_info.value).lower()
+
+    def test_rejects_traversal(self):
+        with pytest.raises(ValidationError) as exc_info:
+            PlanTask(**_make_plan_task(source=["../escape/foo.mp3"]))
+        assert "traversal" in str(exc_info.value).lower() or ".." in str(exc_info.value)
+
+    def test_rejects_traversal_mid_path(self):
+        with pytest.raises(ValidationError):
+            PlanTask(**_make_plan_task(source=["assets/../etc/passwd"]))
+
+    def test_rejects_empty_string_entry(self):
+        with pytest.raises(ValidationError):
+            PlanTask(**_make_plan_task(source=[""]))
+
+    def test_rejects_scheme_only(self):
+        with pytest.raises(ValidationError):
+            PlanTask(**_make_plan_task(source=["context://"]))
+
+    def test_planner_task_same_validation(self):
+        with pytest.raises(ValidationError):
+            PlannerTask(**_make_planner_task(source=["file:///etc/passwd"]))

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -1555,3 +1555,116 @@ class TestVerifyNormalization:
     def test_invalid_type_raises_on_planner_task(self):
         with pytest.raises(Exception, match="verify must be a string or a list"):
             PlannerTask(verify={"bad": "type"}, **self._planner_kwargs())
+
+
+class TestSourceField:
+    def _task(
+        self,
+        task_id: str = "001",
+        source: list[str] | None = None,
+        verify: list[str] | None = None,
+    ) -> PlanTask:
+        return PlanTask(
+            id=task_id,
+            spec="AUDIO",
+            title="Copy SFX",
+            description="bundle audio",
+            outputs=["src/assets/*.mp3"],
+            depends_on=[],
+            spec_refs=[],
+            arch_refs=[],
+            status=TaskStatus.PENDING,
+            verify=verify if verify is not None else [],
+            source=source or [],
+        )
+
+    def test_write_plan_emits_source_with_context_prefix(self, temp_dir: Path):
+        plan = Plan(
+            meta=PlanMeta(generated_at="2026-01-01T00:00:00Z", total_tasks=1, specs=["AUDIO"]),
+            tasks=[self._task(source=["assets/audio/*.mp3"])],
+        )
+        filepath = temp_dir / "plan.toml"
+        write_plan(plan, filepath)
+        content = filepath.read_text()
+        assert "source =" in content
+        assert "context://assets/audio/*.mp3" in content
+
+    def test_write_plan_omits_source_when_empty(self, temp_dir: Path):
+        plan = Plan(
+            meta=PlanMeta(generated_at="2026-01-01T00:00:00Z", total_tasks=1, specs=["AUDIO"]),
+            tasks=[self._task(source=[])],
+        )
+        filepath = temp_dir / "plan.toml"
+        write_plan(plan, filepath)
+        assert "source" not in filepath.read_text()
+
+    def test_roundtrip_source_strips_prefix_on_load(self, temp_dir: Path):
+        plan = Plan(
+            meta=PlanMeta(generated_at="2026-01-01T00:00:00Z", total_tasks=1, specs=["AUDIO"]),
+            tasks=[self._task(source=["audio/*.mp3"])],
+        )
+        filepath = temp_dir / "plan.toml"
+        write_plan(plan, filepath)
+        loaded = load_plan(filepath)
+        assert loaded is not None
+        assert loaded.tasks[0].source == ["audio/*.mp3"]
+
+    def test_load_plan_without_source_defaults_empty(self, temp_dir: Path):
+        plan = Plan(
+            meta=PlanMeta(generated_at="2026-01-01T00:00:00Z", total_tasks=1, specs=["AUDIO"]),
+            tasks=[self._task(source=[])],
+        )
+        filepath = temp_dir / "plan.toml"
+        write_plan(plan, filepath)
+        loaded = load_plan(filepath)
+        assert loaded.tasks[0].source == []
+
+    def test_load_plan_warns_when_source_and_verify_both_set(self, temp_dir: Path):
+        filepath = temp_dir / "plan.toml"
+        filepath.write_text(
+            '[meta]\ngenerated_at = "x"\ntotal_tasks = 1\nspecs = ["AUDIO"]\n\n'
+            "[[task]]\n"
+            'id = "001"\nspec = "AUDIO"\ntitle = "x"\ndescription = "x"\n'
+            'outputs = ["a"]\ndepends_on = []\nspec_refs = []\narch_refs = []\n'
+            'status = "pending"\nverify = ["echo hi"]\n'
+            'source = ["context://a"]\n'
+        )
+        with pytest.warns(UserWarning, match="ignored for copy tasks"):
+            load_plan(filepath)
+
+    def test_format_previous_tasks_includes_source(self):
+        tasks = [self._task(source=["a/b.mp3"])]
+        out = _format_previous_tasks(tasks)
+        assert "source: ['a/b.mp3']" in out
+
+    def test_merge_into_global_plan_propagates_source(self):
+        smds = [make_smd("AUDIO")]
+        graph = SpecGraph(
+            specs=[SpecGraphEntry(id="AUDIO", file="specs/audio.smd", depends=[])],
+            levels=[["AUDIO"]],
+        )
+        spec_plans = {
+            "AUDIO": SpecTaskPlan(
+                tasks=[
+                    PlannerTask(
+                        title="Copy SFX",
+                        description="bundle",
+                        outputs=["src/*.mp3"],
+                        depends_on=[],
+                        spec_refs=[],
+                        arch_refs=[],
+                        verify=[],
+                        source=["context://assets/*.mp3"],
+                    )
+                ]
+            )
+        }
+        plan = merge_into_global_plan(spec_plans, graph, smds)
+        assert plan.tasks[0].source == ["assets/*.mp3"]
+
+    def test_preserved_task_ref_carries_source(self):
+        old_task = self._task(source=["assets/*.mp3"])
+        spec_plan = SpecTaskPlan(tasks=[PreservedTaskRef(previous_index=1, depends_on=[])])
+        resolved = _resolve_preserved_refs(spec_plan, [old_task])
+        assert isinstance(resolved.tasks[0], PlannerTask)
+        assert resolved.tasks[0].source == ["assets/*.mp3"]

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -1668,3 +1668,14 @@ class TestSourceField:
         resolved = _resolve_preserved_refs(spec_plan, [old_task])
         assert isinstance(resolved.tasks[0], PlannerTask)
         assert resolved.tasks[0].source == ["assets/*.mp3"]
+
+    def test_write_task_definitions_emits_source_with_prefix(self, temp_dir: Path):
+        plan = Plan(
+            meta=PlanMeta(generated_at="2026-01-01T00:00:00Z", total_tasks=1, specs=["AUDIO"]),
+            tasks=[self._task(source=["assets/audio/*.mp3"])],
+        )
+        tasks_dir = temp_dir / "tasks"
+        write_task_definitions(plan, tasks_dir)
+        task_dirs = sorted(tasks_dir.iterdir())
+        content = (task_dirs[0] / "task.toml").read_text()
+        assert "context://assets/audio/*.mp3" in content


### PR DESCRIPTION
**What does this change?**

Resolves #26

Adds an optional `source` field to tasks in `plan.toml`. When set, the build copies the matched file(s) directly from the context directory to the output path with no LLM call, no verify, and no fix loop, while the task still participates in the dependency graph and state tracking. This way, project outputs can ship verbatim assets: binary files, fixtures, reference data,etc...

- `source` accepts one or more `context://<path-or-glob>` patterns, paired 1:1 by index with `outputs`. Each pattern allows at most one `*` or `**` wildcard, and the wildcard slots align between source and output.
- New `build/copy.py` module owns the copy execution path. `execute_build` branches on `task.source`; `build_task` itself remained as is.
- Input-hash invalidation folds in the matched source-file content, so a copy task re-runs when its source files or the matched set change.
- The planner LLM is instructed to emit copy tasks for verbatim assets instead of relying on the `copy_context_file` build tool. Existing plans without `source` are unaffected (the change is purely additive).

**How was it tested?**

- New tests to cover new behavior and adjustments on existing tests
- Example projects (math_quest) uses copy tasks properly