### PR TITLE
fix: skip fix loop when expected outputs are missing

### DIFF
--- a/docs/configuration/ossature-toml.md
+++ b/docs/configuration/ossature-toml.md
@@ -55,8 +55,9 @@ Controls how many times the audit will attempt to fix errors in a spec and re-au
 
 ```toml
 [build]
-max_fix_attempts = 3                  # verify-fail → fix → re-verify cycles per task
+max_fix_attempts = 3                  # verify-fail -> fix -> re-verify cycles per task
 max_inline_lines = 200                # files above this aren't inlined in fix prompts
+max_output_tokens = 32768             # per-call output token limit for the build LLM
 setup = ["cargo init"]                # optional: run before the first task
 verify = ["cargo check"]              # optional: override default verification
 test = ["cargo test"]                 # optional: override default test command
@@ -78,6 +79,8 @@ The `setup` commands run once before the first build task. Useful for project in
 The `verify` and `test` commands override what Ossature uses to check generated code. If not set, the LLM determines verification commands per task based on the language and project structure.
 
 The `max_inline_lines` field controls when files are inlined in fix prompts. When a task fails verification, Ossature sends the fixer LLM the error output and the current file contents. Files with more lines than this threshold are not inlined; the fixer uses its `read_lines` and `grep_file` tools to inspect them instead. This prevents blowing up the prompt on large files. Defaults to 200.
+
+The `max_output_tokens` field caps how much output the implementer and fixer agents can produce in a single LLM call. A single `write_file` tool call counts toward this budget, so tasks that produce very large source files (a few thousand lines) can hit the cap. Defaults to 32768, which fits most files comfortably. If you see "Model token limit exceeded before any response was generated", bump this higher. Sonnet-class models can go up to 64000 or so.
 
 ## LLM Section
 

--- a/src/ossature/build/builder.py
+++ b/src/ossature/build/builder.py
@@ -345,7 +345,7 @@ def _create_impl_agent(config: OssatureConfig) -> Agent[BuildContext, str]:
         system_prompt=render("build.implementer", language=config.output.language),
         deps_type=BuildContext,
         retries=config.llm.tool_retries,
-        model_settings={"max_tokens": 16384},
+        model_settings={"max_tokens": config.build.max_output_tokens},
     )
     _register_tools(agent)
     return agent
@@ -357,7 +357,7 @@ def _create_fix_agent(config: OssatureConfig) -> Agent[BuildContext, str]:
         system_prompt=render("build.fixer", language=config.output.language),
         deps_type=BuildContext,
         retries=config.llm.tool_retries,
-        model_settings={"max_tokens": 16384},
+        model_settings={"max_tokens": config.build.max_output_tokens},
     )
     _register_tools(agent)
     return agent
@@ -704,28 +704,33 @@ def assemble_fix_prompt(
     if verify_command:
         sections.append(f"<verify_command>\n{verify_command}\n</verify_command>")
 
-    # Include output files, falling back to inject_files for modify-in-place tasks
+    # Include output files, falling back to inject_files for modify-in-place tasks.
+    # Files in task.outputs that don't exist on disk are filtered out upstream by
+    # build_task, which short-circuits to a missing-outputs failure rather than
+    # entering the fix loop. So here we only see files that actually exist (or
+    # inject_files that may legitimately not exist for unusual modify-in-place flows).
     file_list = task.outputs if task.outputs else (task.inject_files or [])
     for filepath in file_list:
         full_path = config.output_path / filepath
-        if full_path.exists():
-            try:
-                content = full_path.read_text()
-            except UnicodeDecodeError:
-                continue
+        if not full_path.exists():
+            continue
+        try:
+            content = full_path.read_text()
+        except UnicodeDecodeError:
+            continue
 
-            line_count = content.count("\n") + 1
-            if line_count > config.build.max_inline_lines:
-                sections.append(
-                    f'<current_file path="{filepath}" total_lines="{line_count}">\n'
-                    f"File is large. Use `read_lines` or `grep_file` to inspect "
-                    f"the regions referenced in the error output above.\n"
-                    f"</current_file>"
-                )
-            else:
-                sections.append(
-                    f'<current_file path="{filepath}">\n```\n{content}\n```\n</current_file>'
-                )
+        line_count = content.count("\n") + 1
+        if line_count > config.build.max_inline_lines:
+            sections.append(
+                f'<current_file path="{filepath}" total_lines="{line_count}">\n'
+                f"File is large. Use `read_lines` or `grep_file` to inspect "
+                f"the regions referenced in the error output above.\n"
+                f"</current_file>"
+            )
+        else:
+            sections.append(
+                f'<current_file path="{filepath}">\n```\n{content}\n```\n</current_file>'
+            )
 
     sections.append(f"<task>\n**{task.title}**: {task.description}\n</task>")
 
@@ -947,6 +952,30 @@ def _print_verify_command_error(console: Console, task: PlanTask, verify_output:
     )
 
 
+def _print_missing_outputs_error(console: Console, task: PlanTask, missing: list[str]) -> None:
+    missing_lines = "\n".join(f"  - {f}" for f in missing)
+    body = (
+        "The implementer did not produce the files this task is supposed to create. "
+        "The fix loop won't run because the fixer doesn't have the spec/architecture "
+        "context the original implementer had, so it can't faithfully write the missing "
+        "files from scratch.\n\n"
+        f"Missing outputs:\n{missing_lines}\n\n"
+        f"Investigate [cyan].ossature/tasks/{task.id}-*/[/cyan] to see what the "
+        "implementer returned. You can simplify the task description, switch model, "
+        f"or just retry with [cyan]ossature retry --only {task.id}[/cyan]."
+    )
+    console.print()
+    console.print(
+        Panel(
+            body,
+            title="[bold red]Missing Outputs[/bold red]",
+            border_style="red",
+            expand=False,
+            box=box.ROUNDED,
+        )
+    )
+
+
 @dataclass
 class TaskResult:
     success: bool
@@ -1062,11 +1091,39 @@ def build_task(
     task_usage = UsageTracker()
     build_model = config.llm.model_for("build")
 
-    # Implementation
-    build_ctx.set_phase("-- generating...")
-    gen_output = backend.generate(
-        prompt, build_ctx, console, tracker=task_usage, model_name=build_model
-    )
+    # Implementation. If the task expects outputs but the agent returns
+    # without invoking any file-writing tool, retry with a stronger
+    # reminder. Some models occasionally respond with prose like "let's
+    # write game.lua now" but never call write_file.
+    expects_outputs = bool(task.outputs)
+    impl_prompt = prompt
+    noop_attempt = 0
+    while True:
+        build_ctx.set_phase("-- generating...")
+        files_before = set(build_ctx.created_files) | set(build_ctx.edited_files)
+        gen_output = backend.generate(
+            impl_prompt, build_ctx, console, tracker=task_usage, model_name=build_model
+        )
+        files_after = set(build_ctx.created_files) | set(build_ctx.edited_files)
+        if not expects_outputs or files_after != files_before:
+            break
+        if noop_attempt >= _MAX_NOOP_RETRIES:
+            console.log(
+                f"    [yellow]Implementer made no changes after {noop_attempt + 1} "
+                f"attempts, moving on[/yellow]"
+            )
+            break
+        noop_attempt += 1
+        console.log(
+            f"    [yellow]Implementer made no changes (attempt {noop_attempt}), retrying[/yellow]"
+        )
+        impl_prompt = (
+            prompt + "\n\n<important>\n"
+            "You MUST use `write_file` to create the files listed in this task's "
+            "outputs. Do not respond with only prose describing what you would "
+            "write. Call the tool.\n"
+            "</important>"
+        )
     (task_dir / "response.md").write_text(gen_output)
 
     def _make_result(success: bool) -> TaskResult:
@@ -1099,6 +1156,19 @@ def build_task(
     # Check if the error is a command invocation problem, not a code problem
     if is_verify_command_error(verify_output, config.output_path):
         _print_verify_command_error(console, task, verify_output)
+        save_task_output(
+            task_dir, build_ctx.created_files, build_ctx.edited_files, False, verify_output
+        )
+        return _make_result(False)
+
+    # If any expected outputs are missing on disk, skip the fix loop. The
+    # fixer only sees the verify error, the current file contents, and the
+    # task title/description. It doesn't have the spec/arch/inject context
+    # the implementer had, so it can't faithfully write missing files from
+    # scratch. The noop retry already gave the implementer multiple chances.
+    missing_outputs = [f for f in task.outputs if not (config.output_path / f).exists()]
+    if missing_outputs:
+        _print_missing_outputs_error(console, task, missing_outputs)
         save_task_output(
             task_dir, build_ctx.created_files, build_ctx.edited_files, False, verify_output
         )

--- a/src/ossature/config/loader.py
+++ b/src/ossature/config/loader.py
@@ -38,6 +38,10 @@ class AuditConfig:
 class BuildConfig:
     max_fix_attempts: int = 3
     max_inline_lines: int = 200
+    # Per-call output token limit passed to the implementer and fixer
+    # agents. Large enough to fit a full source file in one write_file
+    # tool call. Bump higher if your prompts produce very large files.
+    max_output_tokens: int = 32768
     setup: list[str] = field(default_factory=list)
     verify: list[str] = field(default_factory=list)
     test: list[str] = field(default_factory=list)
@@ -198,6 +202,7 @@ def _parse_build_config(data: dict[str, Any]) -> BuildConfig:
     return BuildConfig(
         max_fix_attempts=int(data.get("max_fix_attempts", 3)),
         max_inline_lines=int(data.get("max_inline_lines", 200)),
+        max_output_tokens=int(data.get("max_output_tokens", 32768)),
         setup=_coerce_command_list(data.get("setup")),
         verify=_coerce_command_list(data.get("verify")),
         test=_coerce_command_list(data.get("test")),

--- a/tests/unit/test_build_task.py
+++ b/tests/unit/test_build_task.py
@@ -36,6 +36,7 @@ def _make_config(tmp_path: Path) -> Any:
     config.context_path.mkdir()
     config.llm.model_for.return_value = "test-model"
     config.build.max_fix_attempts = 3
+    config.build.max_inline_lines = 200
     return config
 
 
@@ -46,11 +47,16 @@ class FakeBackend:
         self,
         verify_results: list[tuple[bool, str]] | None = None,
         fix_side_effects: list[str | AgentRunError] | None = None,
+        generate_noop_count: int = 0,
     ) -> None:
         self._verify_results = list(verify_results or [(True, "")])
         self._verify_idx = 0
         self._fix_side_effects = list(fix_side_effects or [])
         self._fix_idx = 0
+        # Number of leading generate() calls that should NOT write a file.
+        # After that many noops, generate() simulates a real implementer
+        # by adding a file to ctx.created_files.
+        self._generate_noop_remaining = generate_noop_count
         self.generate_calls: list[str] = []
         self.fix_calls: list[str] = []
         self.verify_calls: list[list[str]] = []
@@ -64,6 +70,15 @@ class FakeBackend:
         model_name: str,
     ) -> str:
         self.generate_calls.append(prompt)
+        if self._generate_noop_remaining > 0:
+            self._generate_noop_remaining -= 1
+            return "no tools called"
+        # Simulate the implementer writing the task's output to disk so the
+        # missing-outputs check in build_task is satisfied.
+        output_file = ctx.output_dir / "src" / "main.rs"
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text("// generated stub\n")
+        ctx.created_files.append("src/main.rs")
         return "generated code"
 
     def fix(
@@ -201,6 +216,101 @@ class TestBuildTaskFixLoop:
         assert result.success is True
         # 2 fix calls: 1 no-op + 1 real
         assert len(backend.fix_calls) == 2
+
+
+class TestBuildTaskImplementerNoop:
+    def test_noop_implementer_retries_then_succeeds(self, tmp_path: Path) -> None:
+        # First two generate() calls do nothing, third writes a file.
+        backend = FakeBackend(
+            verify_results=[(True, "ok")],
+            generate_noop_count=2,
+        )
+        result = _run(tmp_path, backend)
+        assert result.success is True
+        assert len(backend.generate_calls) == 3
+        # Second and third prompts should carry the "<important>" nudge
+        assert "<important>" not in backend.generate_calls[0]
+        assert "<important>" in backend.generate_calls[1]
+        assert "<important>" in backend.generate_calls[2]
+
+    def test_noop_implementer_gives_up_and_skips_fix_loop(self, tmp_path: Path) -> None:
+        # Implementer keeps writing nothing. After 3 attempts (initial + 2
+        # retries) the harness moves on, verify fails because the expected
+        # output is missing, and the fix loop is skipped because the fixer
+        # doesn't have the spec context to write the file from scratch.
+        backend = FakeBackend(
+            verify_results=[
+                (False, "luac: cannot open game.lua: No such file or directory"),
+            ],
+            generate_noop_count=99,
+        )
+        result = _run(tmp_path, backend, verify="luac -p game.lua")
+        assert len(backend.generate_calls) == 3
+        assert result.success is False
+        # Fixer was never invoked
+        assert len(backend.fix_calls) == 0
+
+    def test_no_outputs_means_no_noop_retry(self, tmp_path: Path) -> None:
+        backend = FakeBackend(generate_noop_count=99)
+        task = PlanTask(
+            id="010",
+            spec="CORE",
+            title="No-output task",
+            description="",
+            outputs=[],
+            depends_on=[],
+            spec_refs=[],
+            arch_refs=[],
+            verify="",
+        )
+        config = _make_config(tmp_path)
+        result = build_task(task, config, "build prompt", MagicMock(), MagicMock(), backend=backend)
+        assert result.success is True
+        assert len(backend.generate_calls) == 1
+
+
+class TestBuildTaskMissingOutputs:
+    def test_missing_output_skips_fix_loop(self, tmp_path: Path) -> None:
+        # Implementer claims success but the expected output isn't on
+        # disk. build_task should short-circuit before calling the fixer.
+        class WrongPathBackend(FakeBackend):
+            def generate(self, prompt, ctx, console, tracker, model_name):
+                self.generate_calls.append(prompt)
+                # Pretend the implementer wrote somewhere unexpected
+                ctx.created_files.append("wrong/path.rs")
+                return "wrote to the wrong path"
+
+        backend = WrongPathBackend(verify_results=[(False, "error: cannot find main.rs")])
+        result = _run(tmp_path, backend)
+        assert result.success is False
+        assert len(backend.fix_calls) == 0
+
+    def test_missing_one_of_two_outputs_skips_fix_loop(self, tmp_path: Path) -> None:
+        class OneOfTwoBackend(FakeBackend):
+            def generate(self, prompt, ctx, console, tracker, model_name):
+                self.generate_calls.append(prompt)
+                (ctx.output_dir / "src").mkdir(parents=True, exist_ok=True)
+                (ctx.output_dir / "src" / "main.rs").write_text("fn main() {}\n")
+                ctx.created_files.append("src/main.rs")
+                # src/lib.rs was supposed to be produced too but wasn't
+                return "wrote main.rs only"
+
+        backend = OneOfTwoBackend(verify_results=[(False, "error")])
+        task = PlanTask(
+            id="010",
+            spec="CORE",
+            title="Two-output task",
+            description="",
+            outputs=["src/main.rs", "src/lib.rs"],
+            depends_on=[],
+            spec_refs=[],
+            arch_refs=[],
+            verify="cargo check",
+        )
+        config = _make_config(tmp_path)
+        result = build_task(task, config, "build prompt", MagicMock(), MagicMock(), backend=backend)
+        assert result.success is False
+        assert len(backend.fix_calls) == 0
 
 
 class TestBuildTaskArtifacts:

--- a/tests/unit/test_fix_prompt.py
+++ b/tests/unit/test_fix_prompt.py
@@ -102,3 +102,22 @@ class TestAssembleFixPrompt:
 
         result = assemble_fix_prompt(task, "error", config, "cargo test")
         assert "data.bin" not in result or "current_file" not in result
+
+    def test_missing_file_skipped_in_prompt(self, tmp_path: Path) -> None:
+        # build_task short-circuits before assemble_fix_prompt is reached
+        # when expected outputs are missing, so the missing file just
+        # doesn't show up here. No special handling required in the prompt.
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        present = output_dir / "src" / "main.rs"
+        present.parent.mkdir(parents=True)
+        present.write_text("fn main() {}\n")
+
+        task = self._make_task(["src/main.rs", "src/lib.rs"])
+        config = self._make_config(output_dir)
+
+        result = assemble_fix_prompt(task, "missing lib.rs", config, "cargo build")
+        assert "fn main() {}" in result
+        # No special missing-file callout
+        assert "missing_files" not in result
+        assert "src/lib.rs" not in result


### PR DESCRIPTION
When the implementer fails to write its expected output files, Ossature now will fail the task cleanly instead of calling the fixer, which gets stuck anyway. The fixer only has the verify error and the current file contents, no spec or arch context, so expecting it to properly write the missing files would be incorrect. Compile errors and test failures still go through the fix loop as before.