### PR TITLE
Docs and README sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 > [!WARNING]
 > Ossature is currently in its `0.x` series and should be considered **unstable**. APIs, spec formats, CLI flags, and internal behavior may change significantly between releases without prior deprecation. Pin your version and check the [changelog](https://github.com/ossature/ossature/blob/master/CHANGELOG.md) before upgrading.
 
-An open-source harness for spec-driven code generation.
+An open-source build system that turns specs and architecture into working code.
 
-You write a specification, optionally lay out the architecture, and Ossature breaks it down into a build plan that gets executed step by step with an LLM doing the code generation under tight constraints. The specs are your source of truth, you review the plan before anything gets built, and when something breaks you fix that step and keep going instead of starting over.
+You write a spec for what the software does, optionally lay out the architecture for how it fits together, and Ossature turns that into a build plan that runs step by step, with an LLM generating the code under tight constraints. Your specs and architecture are the source, the generated code is the output. You review the plan before anything runs, and when something breaks you fix that step and keep going instead of starting over.
 
 Works with Anthropic, OpenAI, Mistral, Google, and most other hosted providers, as well as local models through Ollama.
 

--- a/docs/advanced/prompts.md
+++ b/docs/advanced/prompts.md
@@ -1,8 +1,8 @@
 # Prompts
 
 The system prompts that drive Ossature's LLM calls are declared as
-PromptSpecs. A PromptSpec is a structured, versioned object that the
-harness renders into a final string at call time, rather than a free
+PromptSpecs. A PromptSpec is a structured, versioned object that
+Ossature renders into a final string at call time, rather than a free
 form template.
 
 Each PromptSpec carries a stable id like `audit.spec_audit` or

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,11 @@
     [changelog](https://github.com/ossature/ossature/blob/master/CHANGELOG.md)
     before upgrading.
 
-**An open-source harness for spec-driven code generation.**
+**An open-source build system that turns specs and architecture into working code.**
 
-You write specifications describing what your software should do, optionally lay out the architecture, and Ossature breaks it down into a build plan that gets executed step by step, with an LLM generating the code under tight constraints.
+You write a spec for what your software should do, optionally lay out the architecture for how it fits together, and Ossature turns that into a build plan that runs step by step, with an LLM generating the code under tight constraints. Your specs and architecture are the source, the generated code is the output.
 
-This is not "throw a prompt at a model and hope for the best." The specs are your source of truth. You review the plan before anything gets built. When something breaks at step 14 of 30, you fix that step and keep going instead of starting over. When requirements change, you update the spec and Ossature figures out what needs to be regenerated.
+This is not "throw a prompt at a model and hope for the best." You review the plan before anything gets built. When something breaks at step 14 of 30, you fix that step and keep going instead of starting over. When requirements change, you update the spec and Ossature figures out what needs to be regenerated.
 
 ## How It Works
 

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -7,6 +7,8 @@ Ossature uses two Markdown-based formats to describe your project:
 | **SMD** (Spec Markdown) | `.smd` | Define *what* the system should do |
 | **AMD** (Architecture Markdown) | `.amd` | Define *how* it should be structured |
 
+Together, the spec and the architecture are the source Ossature builds from, and the generated code is the output.
+
 SMD is required. AMD is optional. If you skip the AMD, the LLM will infer the architecture during the audit phase based on what's in your spec.
 
 ## How They Relate


### PR DESCRIPTION
Like the main site, reposition README and docs around build-system/compiler.